### PR TITLE
Blackfire handle HTTP exceptions properly

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,3 @@
-from logging import raiseExceptions
 import uvicorn
 
 from app.middleware import BlackfireFastAPIMiddleware, patch_fastapi

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
 import uvicorn
+import os
 
 # TODO: This will be removed once blackfire-python includes FastAPI. This function
 # monkey patches FastAPI's middleware stack to ensure Blackfire is on the outermost
 # level.
-from app.middleware import patch_fastapi
-patch_fastapi()
+if os.environ.get("BLACKFIRE_ENABLED", None) == "true":
+    from app.middleware import patch_fastapi
+    patch_fastapi()
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -13,7 +15,6 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse
 
-import os
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
 
 # NLP library

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,9 @@
 import uvicorn
 
-from app.middleware import BlackfireFastAPIMiddleware, patch_fastapi
-
 # TODO: This will be removed once blackfire-python includes FastAPI. This function
 # monkey patches FastAPI's middleware stack to ensure Blackfire is on the outermost
 # level.
+from app.middleware import patch_fastapi
 patch_fastapi()
 
 from fastapi import FastAPI, Request, HTTPException

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,12 @@
+from logging import raiseExceptions
 import uvicorn
+
+from app.middleware import BlackfireFastAPIMiddleware, patch_fastapi
+
+# TODO: This will be removed once blackfire-python includes FastAPI. This function
+# monkey patches FastAPI's middleware stack to ensure Blackfire is on the outermost
+# level.
+patch_fastapi()
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -80,11 +88,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-from app.middleware import BlackfireFastAPIMiddleware
-
-if os.environ.get("BLACKFIRE_ENABLED", None) == "true":
-    app.add_middleware(BlackfireFastAPIMiddleware)
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
 

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,4 +1,5 @@
-from blackfire import apm, profiler
+import os
+from blackfire import apm
 from blackfire.hooks.utils import try_enable_probe, try_end_probe
 
 
@@ -15,8 +16,31 @@ def _extract_headers(d):
         return dict((bytes_to_str(k), bytes_to_str(v)) for (k, v) in headers)
     return {}
 
+def _add_header(response, k, v):
+    response['headers'].append(
+                            [
+                                bytes(k, 'ascii'),
+                                bytes(v, 'ascii')
+                            ]
+                        )
+
+def patch_fastapi():
+    if os.environ.get("BLACKFIRE_ENABLED", None) == "true":
+        from fastapi import FastAPI
+        old_bms = FastAPI.build_middleware_stack
+
+        def bms(self, *args, **kwargs):
+            r = old_bms(self, *args, **kwargs)
+            r = BlackfireFastAPIMiddleware(r)
+            return r
+
+        FastAPI.build_middleware_stack = bms
+
+        print('FastAPI patched successfully.')
+
 
 _FRAMEWORK = 'FastAPI'
+
 
 class BlackfireFastAPIMiddleware:
 
@@ -36,6 +60,9 @@ class BlackfireFastAPIMiddleware:
         server = scope.get('server')
         probe_err = probe = None
         request_headers = _extract_headers(scope)
+        endpoint = None
+        if 'endpoint' in scope:
+            endpoint = scope['endpoint'].__name__
 
         if 'x-blackfire-query' in request_headers:
             probe_err, probe = try_enable_probe(
@@ -49,6 +76,8 @@ class BlackfireFastAPIMiddleware:
 
         content_length = status_code = None
         async def wrapped_send(response):
+            nonlocal content_length, status_code
+
             if response.get("type") == "http.response.start":
                 response_headers = {}
                 if "status" in response:
@@ -59,22 +88,15 @@ class BlackfireFastAPIMiddleware:
 
                 if probe:
                     if probe_err:
-                        pass  # TODO: Add response header
+                        _add_header(response, 'X-Blackfire-Error', probe_err[1])
                     else:
-                        # TODO:
-                        # add_probe_response_header(response.headers, probe_resp)
-                        response['headers'].append(
-                            [
-                                b'X-Blackfire-Response',
-                                bytes(probe.get_agent_prolog_response().status_val, 'ascii')
-                            ]
-                        )
+                        _add_header(response, 'X-Blackfire-Response', probe.get_agent_prolog_response().status_val)
                 elif transaction:
                     #apm._stop_and_queue_transaction(
                     transaction.stop()
                     apm._queue_trace(
                         transaction,
-                        controller_name=transaction.name,  # TODO:
+                        controller_name=transaction.name or endpoint,
                         uri=path,
                         framework=_FRAMEWORK,
                         http_host='http_host',  # TODO:
@@ -84,26 +106,27 @@ class BlackfireFastAPIMiddleware:
                     )
             return await send(response)
 
-        r = await self.app(scope, receive, wrapped_send)
-
-        try_end_probe(
-            probe,
-            response_status_code=status_code,
-            response_len=content_length,
-            controller_name='endpoint',  # TODO
-            framework=_FRAMEWORK,
-            http_method=method,
-            http_uri=path,
-            https='1' if scheme == 'https' else '',
-            http_server_addr=server[0] if server else '',
-            http_server_software='',  # TODO
-            http_server_port=server[1] if server else '',
-            http_header_host=request_headers.get('host'),
-            http_header_user_agent=request_headers
-            .get('user-agent'),
-            http_header_x_forwarded_host='',  # TODO
-            http_header_x_forwarded_proto='',  # TODO
-            http_header_x_forwarded_port='',  # TODO
-            http_header_forwarded='',  # TODO
-        )
-        return r
+        try:
+            return await self.app(scope, receive, wrapped_send)
+        finally:
+            if probe:
+                r = try_end_probe(
+                    probe,
+                    response_status_code=status_code,
+                    response_len=content_length,
+                    controller_name=endpoint,
+                    framework=_FRAMEWORK,
+                    http_method=method,
+                    http_uri=path,
+                    https='1' if scheme == 'https' else '',
+                    http_server_addr=server[0] if server else '',
+                    http_server_software='',  # TODO
+                    http_server_port=server[1] if server else '',
+                    http_header_host=request_headers.get('host'),
+                    http_header_user_agent=request_headers
+                    .get('user-agent'),
+                    http_header_x_forwarded_host='',  # TODO
+                    http_header_x_forwarded_proto='',  # TODO
+                    http_header_x_forwarded_port='',  # TODO
+                    http_header_forwarded='',  # TODO
+                )

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -25,18 +25,17 @@ def _add_header(response, k, v):
                         )
 
 def patch_fastapi():
-    if os.environ.get("BLACKFIRE_ENABLED", None) == "true":
-        from fastapi import FastAPI
-        old_bms = FastAPI.build_middleware_stack
+    from fastapi import FastAPI
+    old_bms = FastAPI.build_middleware_stack
 
-        def bms(self, *args, **kwargs):
-            r = old_bms(self, *args, **kwargs)
-            r = BlackfireFastAPIMiddleware(r)
-            return r
+    def bms(self, *args, **kwargs):
+        r = old_bms(self, *args, **kwargs)
+        r = BlackfireFastAPIMiddleware(r)
+        return r
 
-        FastAPI.build_middleware_stack = bms
+    FastAPI.build_middleware_stack = bms
 
-        print('FastAPI patched successfully.')
+    print('FastAPI patched successfully.')
 
 
 _FRAMEWORK = 'FastAPI'

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,7 +6,7 @@ minfds=1024
 pidfile=/tmp/supervisord.pid
 
 [program:gunicorn]
-command=gunicorn app.main:app -b unix:/run/app.sock -w 4 -k uvicorn.workers.UvicornWorker --forwarded-allow-ips="*"
+command=gunicorn app.main:app -b unix:/run/app.sock -w 4 -k uvicorn.workers.UvicornWorker --forwarded-allow-ips="*" --timeout 120
 autostart=true
 autorestart=true
 


### PR DESCRIPTION
This PR monkey patches FastAPI middleware stack to handle HTTP exceptions. The code will automatically called once `blackfire-python` adds support for FastAPI officially.

Also I needed to increase `gunicorn` worker timeout a bit, because otherwise it timeouts and closes the server which leads to
`Are you authorized to profile this page? No probe response, missing PHP extension or invalid signature for relaying agent.` error. 