### PR TITLE
added languagetool support using aiohttp

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -4,7 +4,7 @@ type: 'python:3.8'
 
 dependencies:
   python3:
-    pipenv: '2018.10.13'
+    pipenv: '2021.5.29'
     supervisor: '*'
 
 web:
@@ -23,6 +23,9 @@ mounts:
   'logs':
     source: local
     source_path: logs
+  'languagetool-server':
+    source: local
+    source_path: 'languagetool-server'
 
 disk: 4096
 
@@ -35,6 +38,17 @@ hooks:
     pipenv run /opt/python/3.8/bin/python3.8 -m spacy download de_core_news_sm
     pipenv run pybabel compile -d locales -l de_DE -f
     pipenv run pybabel compile -d locales -l en_GB -f
+  deploy: |
+    set -e
+    export DIR="languagetool-server"
+    export SERVER="${DIR}.jar"
+    export LT="LanguageTool-5.4"
+    if [ ! -f "${DIR}/${LT}/${SERVER}" ]; then
+      export FILE="${DIR}/${LT}.zip"
+      [ ! -f "$FILE" ] && wget -P "${DIR}" https://languagetool.org/download/${LT}.zip
+      [ ! -f "${DIR}/$LT" ] && unzip $FILE -d "${DIR}"
+      rm -rf "${FILE}"
+    fi
 
 size: L
 resources:

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,8 @@ pytest-cov = "*"
 jinja2 = "*"
 aiofiles = "*"
 babel = "*"
+asyncio = "*"
+aiohttp = "*"
 
 [dev-packages]
 click = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78ef3d0677f4790279c52edb4f0acca49e8ec4b55b9c634f85ccf95eeec2b0e2"
+            "sha256": "1bcc6e6f4cefed3d08f48f65d21fb98653c5f9d6e10e8589181e61733cac13a8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,6 +24,49 @@
             "index": "pypi",
             "version": "==0.7.0"
         },
+        "aiohttp": {
+            "hashes": [
+                "sha256:02f46fc0e3c5ac58b80d4d56eb0a7c7d97fcef69ace9326289fb9f1955e65cfe",
+                "sha256:0563c1b3826945eecd62186f3f5c7d31abb7391fedc893b7e2b26303b5a9f3fe",
+                "sha256:114b281e4d68302a324dd33abb04778e8557d88947875cbf4e842c2c01a030c5",
+                "sha256:14762875b22d0055f05d12abc7f7d61d5fd4fe4642ce1a249abdf8c700bf1fd8",
+                "sha256:15492a6368d985b76a2a5fdd2166cddfea5d24e69eefed4630cbaae5c81d89bd",
+                "sha256:17c073de315745a1510393a96e680d20af8e67e324f70b42accbd4cb3315c9fb",
+                "sha256:209b4a8ee987eccc91e2bd3ac36adee0e53a5970b8ac52c273f7f8fd4872c94c",
+                "sha256:230a8f7e24298dea47659251abc0fd8b3c4e38a664c59d4b89cca7f6c09c9e87",
+                "sha256:2e19413bf84934d651344783c9f5e22dee452e251cfd220ebadbed2d9931dbf0",
+                "sha256:393f389841e8f2dfc86f774ad22f00923fdee66d238af89b70ea314c4aefd290",
+                "sha256:3cf75f7cdc2397ed4442594b935a11ed5569961333d49b7539ea741be2cc79d5",
+                "sha256:3d78619672183be860b96ed96f533046ec97ca067fd46ac1f6a09cd9b7484287",
+                "sha256:40eced07f07a9e60e825554a31f923e8d3997cfc7fb31dbc1328c70826e04cde",
+                "sha256:493d3299ebe5f5a7c66b9819eacdcfbbaaf1a8e84911ddffcdc48888497afecf",
+                "sha256:4b302b45040890cea949ad092479e01ba25911a15e648429c7c5aae9650c67a8",
+                "sha256:515dfef7f869a0feb2afee66b957cc7bbe9ad0cdee45aec7fdc623f4ecd4fb16",
+                "sha256:547da6cacac20666422d4882cfcd51298d45f7ccb60a04ec27424d2f36ba3eaf",
+                "sha256:5df68496d19f849921f05f14f31bd6ef53ad4b00245da3195048c69934521809",
+                "sha256:64322071e046020e8797117b3658b9c2f80e3267daec409b350b6a7a05041213",
+                "sha256:7615dab56bb07bff74bc865307aeb89a8bfd9941d2ef9d817b9436da3a0ea54f",
+                "sha256:79ebfc238612123a713a457d92afb4096e2148be17df6c50fb9bf7a81c2f8013",
+                "sha256:7b18b97cf8ee5452fa5f4e3af95d01d84d86d32c5e2bfa260cf041749d66360b",
+                "sha256:932bb1ea39a54e9ea27fc9232163059a0b8855256f4052e776357ad9add6f1c9",
+                "sha256:a00bb73540af068ca7390e636c01cbc4f644961896fa9363154ff43fd37af2f5",
+                "sha256:a5ca29ee66f8343ed336816c553e82d6cade48a3ad702b9ffa6125d187e2dedb",
+                "sha256:af9aa9ef5ba1fd5b8c948bb11f44891968ab30356d65fd0cc6707d989cd521df",
+                "sha256:bb437315738aa441251214dad17428cafda9cdc9729499f1d6001748e1d432f4",
+                "sha256:bdb230b4943891321e06fc7def63c7aace16095be7d9cf3b1e01be2f10fba439",
+                "sha256:c6e9dcb4cb338d91a73f178d866d051efe7c62a7166653a91e7d9fb18274058f",
+                "sha256:cffe3ab27871bc3ea47df5d8f7013945712c46a3cc5a95b6bee15887f1675c22",
+                "sha256:d012ad7911653a906425d8473a1465caa9f8dea7fcf07b6d870397b774ea7c0f",
+                "sha256:d9e13b33afd39ddeb377eff2c1c4f00544e191e1d1dee5b6c51ddee8ea6f0cf5",
+                "sha256:e4b2b334e68b18ac9817d828ba44d8fcb391f6acb398bcc5062b14b2cbeac970",
+                "sha256:e54962802d4b8b18b6207d4a927032826af39395a3bd9196a5af43fc4e60b009",
+                "sha256:f705e12750171c0ab4ef2a3c76b9a4024a62c4103e3a55dd6f99265b9bc6fcfc",
+                "sha256:f881853d2643a29e643609da57b96d5f9c9b93f62429dcc1cbb413c7d07f0e1a",
+                "sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95"
+            ],
+            "index": "pypi",
+            "version": "==3.7.4.post0"
+        },
         "asgiref": {
             "hashes": [
                 "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9",
@@ -31,6 +74,24 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.4.1"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
+                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
+            ],
+            "markers": "python_full_version >= '3.5.3'",
+            "version": "==3.0.1"
+        },
+        "asyncio": {
+            "hashes": [
+                "sha256:83360ff8bc97980e4ff25c964c7bd3923d333d177aa4f7fb736b019f26c7cb41",
+                "sha256:b62c9157d36187eca799c378e572c969f0da87cd5fc42ca372d92cdb06e7e1de",
+                "sha256:c46a87b48213d7464f22d9a497b9eef8c1928b68320a2fa94240f969f6fec08c",
+                "sha256:c4d18b22701821de07bd6aea8b53d21449ec0ec5680645e5317062ea21817d2d"
+            ],
+            "index": "pypi",
+            "version": "==3.4.3"
         },
         "attrs": {
             "hashes": [
@@ -81,6 +142,14 @@
             ],
             "version": "==2021.5.30"
         },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
         "charset-normalizer": {
             "hashes": [
                 "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6",
@@ -91,11 +160,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==7.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
         },
         "coverage": {
             "hashes": [
@@ -307,6 +376,49 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a",
+                "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93",
+                "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632",
+                "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656",
+                "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79",
+                "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7",
+                "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d",
+                "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5",
+                "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224",
+                "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26",
+                "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea",
+                "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348",
+                "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6",
+                "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76",
+                "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1",
+                "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f",
+                "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952",
+                "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a",
+                "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37",
+                "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9",
+                "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359",
+                "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8",
+                "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da",
+                "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3",
+                "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d",
+                "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf",
+                "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841",
+                "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d",
+                "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93",
+                "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f",
+                "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647",
+                "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635",
+                "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456",
+                "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda",
+                "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5",
+                "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281",
+                "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.1.0"
         },
         "murmurhash": {
             "hashes": [
@@ -581,22 +693,22 @@
         },
         "spacy": {
             "hashes": [
-                "sha256:090ea698d5f4ed468386a038190f836093ca006a2c8a244ed0cb9952d83b39db",
-                "sha256:30d65483eda3c8e27ddf17a68f29a91cc1e572a60888d8759a0baa7145edd62a",
-                "sha256:4bc9faddc9ed4f042ad424af4ff5cb67d193ce4e22ad19d59ff1a14715f113b5",
-                "sha256:6d88e0474d4cdb4a6a440ea145f522e642ddb1ba6eb119e45f8d6ba340ba5420",
-                "sha256:85d4638ace39d7a39a47a0bbca93f6d163694be74bc319189a35e598332df3d0",
-                "sha256:87927de0cc36d24525aa854c37020eb6bb28ffbae2d589638f408abed6b83f9a",
-                "sha256:8b9b22e4486573233e5aad19b94838d559547c31b8db17d550538a7d96545c62",
-                "sha256:8cf175a70ef726641dd53391c109fdb6d424c9ea870e879cde92788781fe6efd",
-                "sha256:a7ad178afb7938b1ae83a7ab18895d596d17cb140d4e9c8b65db0e19df139855",
-                "sha256:d1937bddcb41f14c35821d83b0249c28ef7e557fff0624999fcda65c404c91b9",
-                "sha256:e01d05497d08755c6e4e72125602e9bcc4285b8846fbc3ab7d14e821d41ed84c",
-                "sha256:e164190bf7dc55d7bc5edfda3f787b391dff1d55db1676a013402f3441416da5",
-                "sha256:e33b1a843a042a16d7a8411728917758fc532175b4f36b579b907f71afc8064e"
+                "sha256:0a8791b54ab4a6b92e07ba6bf1d1b1dbbc5dd9311e90a003fac4274fff5fb847",
+                "sha256:1c7b721663d884412a57c499fab3d8ee9be8a614bbb20fcbbbdf0e9e7ad52c33",
+                "sha256:2930683257e228acd7c3294895a1681cc38e4d91b06d43bdd03721aa277dd9d4",
+                "sha256:4a91237bf8eafb23f61e4d07953c94c8f187e3169c5563b0972bf23f52996c3d",
+                "sha256:58084e64a27997192ea48f18abb30ec148c5bbe79d04d17ba4d2fc262100c2a2",
+                "sha256:5937d05aad1f699c60ccc53b49f3f5b4aa4e12cce4b1dca6f5a015592b49565c",
+                "sha256:7465a2c0950cf9ea2fcfeb63a093fb0dc2557b0c3e2f96b89c163477b160f6be",
+                "sha256:838372223e605beff9a0bb563263cf6c3aa0eed1b58c1fa795f20d6938902d5c",
+                "sha256:b51effb8423e0190f22d29d5b98e31a38c9a20b6908d305c5f62d8790f2d0ab3",
+                "sha256:b69e83f4fc4e936735f285dbf452288f6bcb627be824ea6aff41703c2847ddc1",
+                "sha256:b73287620ca6532f95b97111036ba8f4d82ee28ce113acf9b9adbf42b968ef3d",
+                "sha256:ca719d352b13c2d37db8567eb88cda598dfc37fd8465c6187002ff3d020bab86",
+                "sha256:e8342ce5e095f57dd53127a429d9cac38c36e1a353ed9747ef92751216fcd42a"
             ],
             "index": "pypi",
-            "version": "==3.1.2"
+            "version": "==3.1.3"
         },
         "spacy-legacy": {
             "hashes": [
@@ -662,19 +774,19 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:80aead664e6c1672c4ae20dc50e1cdc5e20eeff9b14aa23ecd426375b28be588",
-                "sha256:a4d6d112e507ef98513ac119ead1159d286deab17dffedd96921412c2d236ff5"
+                "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c",
+                "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.62.2"
+            "version": "==4.62.3"
         },
         "typer": {
             "hashes": [
-                "sha256:5455d750122cff96745b0dec87368f56d023725a7ebc9d2e54dd23dc86816303",
-                "sha256:ba58b920ce851b12a2d790143009fa00ac1d05b3ff3257061ff69dbdfc3d161b"
+                "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd",
+                "sha256:d81169725140423d072df464cad1ff25ee154ef381aaf5b8225352ea187ca338"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.3.2"
+            "version": "==0.4.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -686,11 +798,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
-                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
-            "version": "==1.26.6"
+            "version": "==1.26.7"
         },
         "uvicorn": {
             "extras": [
@@ -767,16 +879,59 @@
                 "sha256:ff59c6bdb87b31f7e2d596f09353d5a38c8c8ff571b0e2238e8ee2d55ad68465"
             ],
             "version": "==10.0"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:00d7ad91b6583602eb9c1d085a2cf281ada267e9a197e8b7cae487dadbfa293e",
+                "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434",
+                "sha256:15263c3b0b47968c1d90daa89f21fcc889bb4b1aac5555580d74565de6836366",
+                "sha256:2ce4c621d21326a4a5500c25031e102af589edb50c09b321049e388b3934eec3",
+                "sha256:31ede6e8c4329fb81c86706ba8f6bf661a924b53ba191b27aa5fcee5714d18ec",
+                "sha256:324ba3d3c6fee56e2e0b0d09bf5c73824b9f08234339d2b788af65e60040c959",
+                "sha256:329412812ecfc94a57cd37c9d547579510a9e83c516bc069470db5f75684629e",
+                "sha256:4736eaee5626db8d9cda9eb5282028cc834e2aeb194e0d8b50217d707e98bb5c",
+                "sha256:4953fb0b4fdb7e08b2f3b3be80a00d28c5c8a2056bb066169de00e6501b986b6",
+                "sha256:4c5bcfc3ed226bf6419f7a33982fb4b8ec2e45785a0561eb99274ebbf09fdd6a",
+                "sha256:547f7665ad50fa8563150ed079f8e805e63dd85def6674c97efd78eed6c224a6",
+                "sha256:5b883e458058f8d6099e4420f0cc2567989032b5f34b271c0827de9f1079a424",
+                "sha256:63f90b20ca654b3ecc7a8d62c03ffa46999595f0167d6450fa8383bab252987e",
+                "sha256:68dc568889b1c13f1e4745c96b931cc94fdd0defe92a72c2b8ce01091b22e35f",
+                "sha256:69ee97c71fee1f63d04c945f56d5d726483c4762845400a6795a3b75d56b6c50",
+                "sha256:6d6283d8e0631b617edf0fd726353cb76630b83a089a40933043894e7f6721e2",
+                "sha256:72a660bdd24497e3e84f5519e57a9ee9220b6f3ac4d45056961bf22838ce20cc",
+                "sha256:73494d5b71099ae8cb8754f1df131c11d433b387efab7b51849e7e1e851f07a4",
+                "sha256:7356644cbed76119d0b6bd32ffba704d30d747e0c217109d7979a7bc36c4d970",
+                "sha256:8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10",
+                "sha256:8aa3decd5e0e852dc68335abf5478a518b41bf2ab2f330fe44916399efedfae0",
+                "sha256:97b5bdc450d63c3ba30a127d018b866ea94e65655efaf889ebeabc20f7d12406",
+                "sha256:9ede61b0854e267fd565e7527e2f2eb3ef8858b301319be0604177690e1a3896",
+                "sha256:b2e9a456c121e26d13c29251f8267541bd75e6a1ccf9e859179701c36a078643",
+                "sha256:b5dfc9a40c198334f4f3f55880ecf910adebdcb2a0b9a9c23c9345faa9185721",
+                "sha256:bafb450deef6861815ed579c7a6113a879a6ef58aed4c3a4be54400ae8871478",
+                "sha256:c49ff66d479d38ab863c50f7bb27dee97c6627c5fe60697de15529da9c3de724",
+                "sha256:ce3beb46a72d9f2190f9e1027886bfc513702d748047b548b05dab7dfb584d2e",
+                "sha256:d26608cf178efb8faa5ff0f2d2e77c208f471c5a3709e577a7b3fd0445703ac8",
+                "sha256:d597767fcd2c3dc49d6eea360c458b65643d1e4dbed91361cf5e36e53c1f8c96",
+                "sha256:d5c32c82990e4ac4d8150fd7652b972216b204de4e83a122546dce571c1bdf25",
+                "sha256:d8d07d102f17b68966e2de0e07bfd6e139c7c02ef06d3a0f8d2f0f055e13bb76",
+                "sha256:e46fba844f4895b36f4c398c5af062a9808d1f26b2999c58909517384d5deda2",
+                "sha256:e6b5460dc5ad42ad2b36cca524491dfcaffbfd9c8df50508bddc354e787b8dc2",
+                "sha256:f040bcc6725c821a4c0665f3aa96a4d0805a7aaf2caf266d256b8ed71b9f041c",
+                "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a",
+                "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.6.3"
         }
     },
     "develop": {
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==7.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
         },
         "polib": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ For an alternate view of the docs navigate to http://localhost:8000/redoc
 Set an env variable `API_DOCS_AUTH_ENABLED` to `"true"` and for the username/password called `API_DOCS_USERNAME` and `API_DOCS_PASSWORD` for basic auth for the API docs.
 
 Set am env variable `LANGUAGETOOL_API` to the URL endpoint of your LanguageTool server.
-Default is `https://api.languagetool.org/v2`.
 
 If the build fails due to "No space left on device" while installing the dependencies see:
 https://docs.platform.sh/development/troubleshoot.html#clear-the-build-cache

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ For an alternate view of the docs navigate to http://localhost:8000/redoc
 
 Set an env variable `API_DOCS_AUTH_ENABLED` to `"true"` and for the username/password called `API_DOCS_USERNAME` and `API_DOCS_PASSWORD` for basic auth for the API docs.
 
+Set am env variable `LANGUAGETOOL_API` to the URL endpoint of your LanguageTool server.
+Default is `https://api.languagetool.org/v2`.
+
 If the build fails due to "No space left on device" while installing the dependencies see:
 https://docs.platform.sh/development/troubleshoot.html#clear-the-build-cache
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For an alternate view of the docs navigate to http://localhost:8000/redoc
 Set an env variable `API_DOCS_AUTH_ENABLED` to `"true"` and for the username/password called `API_DOCS_USERNAME` and `API_DOCS_PASSWORD` for basic auth for the API docs.
 
 Set am env variable `LANGUAGETOOL_API` to the URL endpoint of your LanguageTool server.
+Default is `https://api.languagetool.org/v2`.
 
 If the build fails due to "No space left on device" while installing the dependencies see:
 https://docs.platform.sh/development/troubleshoot.html#clear-the-build-cache

--- a/app/lang.py
+++ b/app/lang.py
@@ -11,18 +11,12 @@ from app.models import UserRequestIn
 
 class Lang(object):
     def __init__(self, user_request_in: UserRequestIn):
-        allowed_langs = ["en_GB", "de_DE"]
+        self.locale = self.DetectLanguage(user_request_in)
 
-        if user_request_in.response_lang not in allowed_langs:
-            raise Exception("Response language not supported: " + user_request_in.response_lang)
-
-        self.response_lang = user_request_in.response_lang
-
-        language = gettext.translation("messages", localedir="locales", languages=[user_request_in.response_lang])
+        langs = {"en": "en_GB", "de": "de_DE"}
+        language = gettext.translation("messages", localedir="locales", languages=[langs[self.locale]])
         language.install()
         self._ = language.gettext
-
-        self.locale = self.DetectLanguage(user_request_in)
 
     """Detect the language if none is passed explicitly but only return a language if confidence is high enough"""
     def DetectLanguage(self, user_request_in: UserRequestIn):

--- a/app/main.py
+++ b/app/main.py
@@ -213,9 +213,12 @@ async def check_query(user_request_in: UserRequestIn, background_tasks: Backgrou
 
 # Functions
 async def languagetools(lang, text):
+    url = os.environ.get("LANGUAGETOOL_API", "false")
+    if url == "false":
+        return []
+
     list_results = []
 
-    url = os.environ.get("LANGUAGETOOL_API", "https://api.languagetool.org/v2")
     async with aiohttp.ClientSession() as session:
         payload = {"text": text, "language": lang.locale}
         async with session.post(url + "/check", data=payload) as r:

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,8 @@ import uvicorn
 import os
 import json
 import secrets
+import asyncio
+import aiohttp
 
 # TODO: This will be removed once blackfire-python includes FastAPI. This function
 # monkey patches FastAPI's middleware stack to ensure Blackfire is on the outermost
@@ -170,11 +172,11 @@ def get_root():
     return RedirectResponse(url='/form', status_code=301)
 
 @app.get("/docs", include_in_schema=False)
-async def get_swagger_documentation(username: str = Depends(get_current_username)):
+def get_swagger_documentation(username: str = Depends(get_current_username)):
     return get_swagger_ui_html(openapi_url="/openapi.json", title="docs")
 
 @app.get("/openapi.json", include_in_schema=False)
-async def openapi(username: str = Depends(get_current_username)):
+def openapi(username: str = Depends(get_current_username)):
     return get_openapi(title=app.title, version=app.version, routes=app.routes)
 
 @app.get("/form", response_class=HTMLResponse)
@@ -182,7 +184,7 @@ def form(request: Request):
     return templates.TemplateResponse("form.html", {"request": request})
 
 @app.post("/log")
-async def log(user_request_in: UserRequestInEvent, background_tasks: BackgroundTasks):
+def log(user_request_in: UserRequestInEvent, background_tasks: BackgroundTasks):
     try:
         lang = Lang(user_request_in)
     except Exception as e:
@@ -199,26 +201,9 @@ async def check_query(user_request_in: UserRequestIn, background_tasks: Backgrou
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    #apply SpaCy pre-built model
-    tokens = model[lang.locale](user_request_in.text)
-    
-    #Phrase matcher part to handle False positives with two words and special simbols
-    matcher = PhraseMatcher(model[lang.locale].vocab)
-
-    # Only run model.make_doc to speed things up
-    patterns = [model[lang.locale].make_doc(user_request_in.text) for text in terms_false_positive]
-    matcher.add("TerminologyList", patterns)
-    
-    #functions for German rules
-    if lang.locale == "de":
-        list_results = GermanRules(lang, tokens, user_request_in.text)
-
-    #function for English rules
-    elif lang.locale == "en":
-        list_results = EnglishRules(lang, tokens, user_request_in.text)
-
-    else:
-        list_results = []
+    languagetools_results = await languagetools(lang, user_request_in.text)
+    language_rules_results = language_rules(lang, user_request_in.text)
+    list_results = language_rules_results + languagetools_results
 
     response = ResultsOut.factory(list_results, lang)
 
@@ -227,6 +212,68 @@ async def check_query(user_request_in: UserRequestIn, background_tasks: Backgrou
     return response
 
 # Functions
+async def languagetools(lang, text):
+    list_results = []
+
+    url = os.environ.get("LANGUAGETOOL_API", "https://api.languagetool.org/v2")
+    async with aiohttp.ClientSession() as session:
+        payload = {"text": text, "language": lang.locale}
+        async with session.post(url + "/check", data=payload) as r:
+            result = await r.json()
+
+            if "matches" in result:
+                for match in result["matches"]:
+                    context = match["context"]
+                    offset = int(context["offset"])
+                    end = offset + int(context["length"])
+                    alternatives = []
+                    if "replacements" in match:
+                         for replacement in match["replacements"]:
+                             value = replacement["value"]
+                             value = value if value != "" else "-"
+                             alternatives.append(value)
+
+                    list_results.append(
+                        ResultOut.factory(
+                            lang,
+                            context["text"][offset:end],
+                            match["rule"]["issueType"],
+                            offset,
+                            end,
+                            alternatives,
+                            None,
+                            match["shortMessage"],
+                            "",
+                            match["message"]
+                        )
+                    )
+
+    return list_results
+
+def language_rules(lang, text):
+    #apply SpaCy pre-built model
+    tokens = model[lang.locale](text)
+    
+    #Phrase matcher part to handle False positives with two words and special simbols
+    matcher = PhraseMatcher(model[lang.locale].vocab)
+
+    # Only run model.make_doc to speed things up
+    patterns = [model[lang.locale].make_doc(text) for value in terms_false_positive]
+    matcher.add("TerminologyList", patterns)
+    
+    #functions for German rules
+    if lang.locale == "de":
+        list_results = GermanRules(lang, tokens, text)
+
+    #function for English rules
+    elif lang.locale == "en":
+        list_results = EnglishRules(lang, tokens, text)
+
+    else:
+        list_results = []
+    
+    return list_results
+
 def log_response(user_request_in: UserRequestIn, response: ResultsOut = None):
     if user_request_in.id == None or os.environ.get("LOGGING_ENABLED", None) != "true":
         return

--- a/app/main.py
+++ b/app/main.py
@@ -213,7 +213,7 @@ async def check_query(user_request_in: UserRequestIn, background_tasks: Backgrou
 
 # Functions
 async def languagetools(lang, text):
-    url = os.environ.get("LANGUAGETOOL_API", "false")
+    url = os.environ.get("LANGUAGETOOL_API", "https://api.languagetool.org/v2")
     if url == "false":
         return []
 

--- a/app/models.py
+++ b/app/models.py
@@ -43,7 +43,7 @@ class ResultOut(BaseModel):
     solution: str
     alternatives: List[str]
 
-    def factory(lang, text, category, start, end = None, alternatives = [], subcategory = None):
+    def factory(lang, text, category, start, end = None, alternatives = [], subcategory = None, label = None, reason = None, solution = None):
         if end == None:
             end = start + len(text)
 
@@ -54,9 +54,9 @@ class ResultOut(BaseModel):
         if category == "communal_language" or category == "d_and_i_words":
             alternatives = []
 
-        label = lang._("rules." + category + "_label")
-        reason = lang._("rules." + subcategory + "_reason")
-        solution = lang._("rules." + subcategory + "_solution")
+        label = label if label != None else lang._("rules." + category + "_label")
+        reason = reason if reason != None else lang._("rules." + subcategory + "_reason")
+        solution = solution if solution != None else lang._("rules." + subcategory + "_solution")
 
         return ResultOut(text, category, start, end, alternatives, label, reason, solution)
 

--- a/app/models.py
+++ b/app/models.py
@@ -6,7 +6,6 @@ class UserRequestIn(BaseModel):
     text: str
     lang: Optional[str] = "auto"
     fallback_lang: Optional[str] = "de"
-    response_lang: Optional[str] = "de_DE"
     id: Optional[str] = None
 
     def toDict(self):
@@ -14,7 +13,6 @@ class UserRequestIn(BaseModel):
             "text": self.text,
             "lang": self.lang,
             "fallback_lang": self.fallback_lang,
-            "response_lang": self.response_lang,
         }
 
 class UserRequestInEvent(UserRequestIn):
@@ -27,7 +25,6 @@ class UserRequestInEvent(UserRequestIn):
             "text": self.text,
             "lang": self.lang,
             "fallback_lang": self.fallback_lang,
-            "response_lang": self.response_lang,
             "alternative": self.alternative,
             "start": self.start,
             "end": self.end,

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,6 +10,11 @@ command=gunicorn app.main:app -b unix:/run/app.sock -w 12 -k uvicorn.workers.Uvi
 autostart=true
 autorestart=true
 
+[program:languagetool]
+command=java -cp languagetool-server/LanguageTool-5.4/languagetool-server.jar org.languagetool.server.HTTPServer --port 8010 --allow-origin "*"
+autostart=true
+autorestart=true
+
 [program:blackfire-agent]
 command=/usr/bin/blackfire-agent --config=/etc/blackfire-conf/agent --socket=tcp://127.0.0.1:8307 --log-level=5 --log-file=/tmp/log/app.log
 autostart=true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -71,6 +71,29 @@ def test_api():
         }
     ]
 
+def test_api_typo():
+    request_data = {"text": "Halo Welt"}
+
+    response = client.post("/check", json=request_data)
+    assert response.status_code == 200
+
+    first_record = response.json()
+    assert first_record["language"] == "de"
+    assert first_record["results"] == [
+        {
+        "text": "Halo",
+        "category": "uncategorized",
+        "start": 0,
+        "end": 4,
+        "alternatives": [
+            "Hallo"
+        ],
+        "label": "Mögliche Wortverwechslung: ",
+        "reason": "",
+        "solution": "Meinten Sie die Begrüßung „Hallo“? Ein Halo ist ein Lichteffekt."
+        }
+    ]
+
 def test_api_english():
     request_data = {"text": "We are searching for analytical ninja rockstar programmer for our customers"}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,69 +109,9 @@ def test_api_english():
         "start": 21,
         "end": 31,
         "alternatives": [],
-        "label": "Agentische Sprache",
-        "reason": "Dieser Begriff ist agentisch und beschreibt Eigenschaften, die das männliche Stereotyp als Norm erklären. Menschen, die diesem Stereotyp nicht entsprechen (Frauen, sowie andere unterrepräsentierte Gruppen), fühlen sich durch dieses Wort unbewusst ausgeschlossen.",
-        "solution": "Verwenden Sie eine Wortkombination, die teamorientierter klingt und auf den Sinn in der Arbeit Bezug nimmt."
-        }
-    ]
-
-def test_api_response_lang():
-    request_data = {"text": "Wir suchen Ninja Rockstar Programmierer für unsere Kunden", "response_lang": "en_GB"}
-
-    response = client.post("/check", json=request_data)
-    assert response.status_code == 200
-
-    first_record = response.json()
-    assert first_record["language"] == "de"
-    assert first_record["results"] == [
-        {
-        "text": "Kunden",
-        "category": "gendered_denominations",
-        "start": 51,
-        "end": 57,
-        "alternatives": [
-            "Kund:innen",
-            "Kundinnen und Kunden",
-            "Kundschaft "
-        ],
-        "label": "Gendered Denominations",
-        "reason": "For economic-historical reasons, an image of a man is unconsciously evoked in front of the inner eye, even if the term is linguistically neutral. The female gender or other gender identities therefore do not become visible. And they will not feel to belong in this setting.",
-        "solution": "In order to provoke an inclusive image, be not only linguistically, but also mentally neutral in your formulation. Rather use a noun that describes the activity. Or use a denomination that is truly gender-neutral."
-        },
-        {
-        "text": "Ninja",
-        "category": "boasting_words",
-        "start": 11,
-        "end": 16,
-        "alternatives": [
-            "jemand, der erfahren und fachkundig ist",
-            "jemand mit Know-how und Ausdauer",
-            "Mensch, der seine Fachkenntnis ständig vertieft"
-        ],
-        "label": "Boasting Words",
-        "reason": "With this term you use a language of superlatives. Many people perceive this as negative, as it gives the impression of having to conform in terms of superlatives.",
-        "solution": "Use an authentic and honest sounding statement."
-        },
-        {
-        "text": "Rockstar",
-        "category": "boasting_words",
-        "start": 17,
-        "end": 25,
-        "alternatives": [
-            "jemand, der Meilensteine erreichen will",
-            "strebsam",
-            "fleißig",
-            "jemand, der mit dem Team gemeinsame Ziele verfolgt",
-            "du willst mit dem Team etwas erreichen",
-            "zielorientierter Mensch",
-            "tatkräftige Person",
-            "Tatmensch",
-            "jemand, der unternehmerisch denkt",
-            "jemand, der Ziele mit Elan verfolgt"
-        ],
-        "label": "Boasting Words",
-        "reason": "With this term you use a language of superlatives. Many people perceive this as negative, as it gives the impression of having to conform in terms of superlatives.",
-        "solution": "Use an authentic and honest sounding statement."
+        "label": "Agentic Language",
+        "reason": "This term is agentic, describing attributes that enforce the male stereotype as the the norm. People not falling into that stereotype (women but also other underrepresented groups) will feel unconsciously excluded by this word. ",
+        "solution": "Use a word combination that sounds more team-oriented and refers to the purpose in work."
         }
     ]
 
@@ -184,12 +124,6 @@ def test_api_false_positive():
     first_record = response.json()
     assert first_record["language"] == "en"
     assert first_record["results"] == []
-
-def test_api_missing_response_lang():
-    request_data = {"text": "Greenpeace is an international company with headquarters in London.", "response_lang": "es_ES"}
-
-    response = client.post("/check", json=request_data)
-    assert response.status_code == 400
 
 def test_api_missing_data():
     response = client.post("/check")


### PR DESCRIPTION
fixes #18 

you can try `Halo Welt` on https://pr-90-mbafagy-qh3uq7skrqxzg.de-2.platformsh.site/docs#/default/check_query_check_post

there is a competing PR in #91 but I think this approach is better as it gives us more control (which I used to make this async though I am not sure if the implementation is correct, see my comments).

I removed `response_lang` since this concept isn’t support in LanguageTool and it may also apply to us eventually since it may become too hard to maintain translations for each reason/solution for language specific rules

further reading: https://testdriven.io/blog/concurrency-parallelism-asyncio/
consider usin https://pypi.org/project/pytest-asyncio/

not sure if doing the following with both the LT call and the NLP work is the way to go:
```
async def main():
    tasks = []

    for i in range(5):
        tasks.append(write_genre(f"./async/new_file{i}.txt"))

    await asyncio.gather(*tasks)
```

but generally all we are doing here is helping concurrency, which doesn’t help the latency of individual requests, which may be achieved with parallelism via threading https://towardsdatascience.com/asyncio-is-not-parallelism-70bfed470489

https://medium.com/fintechexplained/advanced-python-concurrency-and-parallelism-82e378f26ced

should do some ApacheBench testing to figure out with which approach we achieve the best balance of latency while serving as many concurrent requests as possible