### PR TITLE
make the workers relative to the available memory

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,7 +16,9 @@ web:
   upstream:
     socket_family: unix
   commands:
-    start: 'gunicorn app.main:app -b unix:$SOCKET -w 12 -k uvicorn.workers.UvicornWorker --forwarded-allow-ips="*"'
+    start: |
+      [ $PLATFORM_ENVIRONMENT_TYPE == "development" ] && WORKERS="6" || WORKERS="$(jq ".info.limits.memory / 250 | tonumber | floor" /run/config.json)"
+      gunicorn app.main:app -b unix:$SOCKET -w ${WORKERS} -k uvicorn.workers.UvicornWorker --forwarded-allow-ips="*"
   locations:
     '/':
       passthru: true


### PR DESCRIPTION
The issue I am looking to fix here is that the dev envs don't have as much resources so we need to reduce the amount of workers. However I also want to generally make the application adjust the amount of workers relative to available resources (ie. if we switch to a bigger plan on platform.sh we launch more workers)

Unfortunately /run/config.json is hardcoded into the image so it doesn't change depending on if its the prod env or the dev env. However since we now that for dev env, its a size S plan (for prod we currently use a size L plan), we know the available resources and so I hardcoded the value there.