### PR TITLE
scrub sentry data with presidio

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,8 @@ redis = "*"
 platformshconfig = "*"
 fakeredis = "*"
 fasttext = "*"
+presidio-anonymizer = "*"
+presidio-analyzer = "*"
 
 [dev-packages]
 click = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1d4be16d796f59396757a0c482537266d494acdccb40f8bd243388b8c626f361"
+            "sha256": "2b9d4d6f852f494da0c565213c622bc192531230ee51bbfd0c5757adceaa018c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -350,6 +350,14 @@
             ],
             "index": "pypi",
             "version": "==0.9.2"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80",
+                "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.2"
         },
         "frozenlist": {
             "hashes": [
@@ -778,6 +786,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.6.1"
         },
+        "phonenumbers": {
+            "hashes": [
+                "sha256:2b8c7a7ffac4fe2be3d8bf20dad316ea1292f27422c9e18b1f3cd16734d4a5ed",
+                "sha256:f477da623a51cba084567d6a67b1882a8aaaf3e7beadad655f8613a8f887ac62"
+            ],
+            "version": "==8.12.41"
+        },
         "platformshconfig": {
             "hashes": [
                 "sha256:3eb95a514de57ce3341690fd3e0a61e6fa8c858a0793810a29fcce40691254a2",
@@ -815,6 +830,20 @@
                 "sha256:fb3b7588a3a0f2f2f1bf3fe403361b2b031212b73a37025aea1df7215af3772a"
             ],
             "version": "==3.0.6"
+        },
+        "presidio-analyzer": {
+            "hashes": [
+                "sha256:f0b40af4e152a46c543fbe08b3cea7d89fe984c5f24011df1fa8b2e1875b5f71"
+            ],
+            "index": "pypi",
+            "version": "==2.2.23"
+        },
+        "presidio-anonymizer": {
+            "hashes": [
+                "sha256:2c363a92e8d4caa604b4b0f507985a487207f3a675b513a06871f21854eed996"
+            ],
+            "index": "pypi",
+            "version": "==2.2.23"
         },
         "protobuf": {
             "hashes": [
@@ -937,6 +966,42 @@
             ],
             "version": "==2.21"
         },
+        "pycryptodome": {
+            "hashes": [
+                "sha256:1181c90d1a6aee68a84826825548d0db1b58d8541101f908d779d601d1690586",
+                "sha256:12c7343aec5a3b3df5c47265281b12b611f26ec9367b6129199d67da54b768c1",
+                "sha256:212c7f7fe11cad9275fbcff50ca977f1c6643f13560d081e7b0f70596df447b8",
+                "sha256:32d15da81959faea6cbed95df2bb44f7f796211c110cf90b5ad3b2aeeb97fc8e",
+                "sha256:341c6bbf932c406b4f3ee2372e8589b67ac0cf4e99e7dc081440f43a3cde9f0f",
+                "sha256:3558616f45d8584aee3eba27559bc6fd0ba9be6c076610ed3cc62bd5229ffdc3",
+                "sha256:39da5807aa1ff820799c928f745f89432908bf6624b9e981d2d7f9e55d91b860",
+                "sha256:3f2f3dd596c6128d91314e60a6bcf4344610ef0e97f4ae4dd1770f86dd0748d8",
+                "sha256:4cded12e13785bbdf4ba1ff5fb9d261cd98162145f869e4fbc4a4b9083392f0b",
+                "sha256:5a8c24d39d4a237dbfe181ea6593792bf9b5582c7fcfa7b8e0e12fda5eec07af",
+                "sha256:5d4264039a2087977f50072aaff2346d1c1c101cb359f9444cf92e3d1f42b4cd",
+                "sha256:6bb0d340c93bcb674ea8899e2f6408ec64c6c21731a59481332b4b2a8143cc60",
+                "sha256:6f8f5b7b53516da7511951910ab458e799173722c91fea54e2ba2f56d102e4aa",
+                "sha256:90ad3381ccdc6a24cc2841e295706a168f32abefe64c679695712acac71fd5da",
+                "sha256:93acad54a72d81253242eb0a15064be559ec9d989e5173286dc21cad19f01765",
+                "sha256:9ea2f6674c803602a7c0437fccdc2ea036707e60456974fe26ca263bd501ec45",
+                "sha256:a6e1bcd9d5855f1a3c0f8d585f44c81b08f39a02754007f374fb8db9605ba29c",
+                "sha256:a78e4324e566b5fbc2b51e9240950d82fa9e1c7eb77acdf27f58712f65622c1d",
+                "sha256:aceb1d217c3a025fb963849071446cf3aca1353282fe1c3cb7bd7339a4d47947",
+                "sha256:aed7eb4b64c600fbc5e6d4238991ad1b4179a558401f203d1fcbd24883748982",
+                "sha256:b07a4238465eb8c65dd5df2ab8ba6df127e412293c0ed7656c003336f557a100",
+                "sha256:b91404611767a7485837a6f1fd20cf9a5ae0ad362040a022cd65827ecb1b0d00",
+                "sha256:d8083de50f6dec56c3c6f270fb193590999583a1b27c9c75bc0b5cac22d438cc",
+                "sha256:d845c587ceb82ac7cbac7d0bf8c62a1a0fe7190b028b322da5ca65f6e5a18b9e",
+                "sha256:db66ccda65d5d20c17b00768e462a86f6f540f9aea8419a7f76cc7d9effd82cd",
+                "sha256:dc88355c4b261ed259268e65705b28b44d99570337694d593f06e3b1698eaaf3",
+                "sha256:de0b711d673904dd6c65307ead36cb76622365a393569bf880895cba21195b7a",
+                "sha256:e05f994f30f1cda3cbe57441f41220d16731cf99d868bb02a8f6484c454c206b",
+                "sha256:e80f7469b0b3ea0f694230477d8501dc5a30a717e94fddd4821e6721f3053eae",
+                "sha256:f699360ae285fcae9c8f53ca6acf33796025a82bb0ccd7c1c551b04c1726def3"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==3.12.0"
+        },
         "pydantic": {
             "hashes": [
                 "sha256:021ea0e4133e8c824775a0cfe098677acf6fa5a3cbf9206a376eed3fc09302cd",
@@ -1042,6 +1107,7 @@
                 "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
                 "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==6.0"
         },
         "redis": {
@@ -1052,6 +1118,85 @@
             "index": "pypi",
             "version": "==4.0.2"
         },
+        "regex": {
+            "hashes": [
+                "sha256:04611cc0f627fc4a50bc4a9a2e6178a974c6a6a4aa9c1cca921635d2c47b9c87",
+                "sha256:0b5d6f9aed3153487252d00a18e53f19b7f52a1651bc1d0c4b5844bc286dfa52",
+                "sha256:0d2f5c3f7057530afd7b739ed42eb04f1011203bc5e4663e1e1d01bb50f813e3",
+                "sha256:11772be1eb1748e0e197a40ffb82fb8fd0d6914cd147d841d9703e2bef24d288",
+                "sha256:1333b3ce73269f986b1fa4d5d395643810074dc2de5b9d262eb258daf37dc98f",
+                "sha256:16f81025bb3556eccb0681d7946e2b35ff254f9f888cff7d2120e8826330315c",
+                "sha256:1a171eaac36a08964d023eeff740b18a415f79aeb212169080c170ec42dd5184",
+                "sha256:1d6301f5288e9bdca65fab3de6b7de17362c5016d6bf8ee4ba4cbe833b2eda0f",
+                "sha256:1e031899cb2bc92c0cf4d45389eff5b078d1936860a1be3aa8c94fa25fb46ed8",
+                "sha256:1f8c0ae0a0de4e19fddaaff036f508db175f6f03db318c80bbc239a1def62d02",
+                "sha256:2245441445099411b528379dee83e56eadf449db924648e5feb9b747473f42e3",
+                "sha256:22709d701e7037e64dae2a04855021b62efd64a66c3ceed99dfd684bfef09e38",
+                "sha256:24c89346734a4e4d60ecf9b27cac4c1fee3431a413f7aa00be7c4d7bbacc2c4d",
+                "sha256:25716aa70a0d153cd844fe861d4f3315a6ccafce22b39d8aadbf7fcadff2b633",
+                "sha256:2dacb3dae6b8cc579637a7b72f008bff50a94cde5e36e432352f4ca57b9e54c4",
+                "sha256:34316bf693b1d2d29c087ee7e4bb10cdfa39da5f9c50fa15b07489b4ab93a1b5",
+                "sha256:36b2d700a27e168fa96272b42d28c7ac3ff72030c67b32f37c05616ebd22a202",
+                "sha256:37978254d9d00cda01acc1997513f786b6b971e57b778fbe7c20e30ae81a97f3",
+                "sha256:38289f1690a7e27aacd049e420769b996826f3728756859420eeee21cc857118",
+                "sha256:385ccf6d011b97768a640e9d4de25412204fbe8d6b9ae39ff115d4ff03f6fe5d",
+                "sha256:3c7ea86b9ca83e30fa4d4cd0eaf01db3ebcc7b2726a25990966627e39577d729",
+                "sha256:49810f907dfe6de8da5da7d2b238d343e6add62f01a15d03e2195afc180059ed",
+                "sha256:519c0b3a6fbb68afaa0febf0d28f6c4b0a1074aefc484802ecb9709faf181607",
+                "sha256:51f02ca184518702975b56affde6c573ebad4e411599005ce4468b1014b4786c",
+                "sha256:552a39987ac6655dad4bf6f17dd2b55c7b0c6e949d933b8846d2e312ee80005a",
+                "sha256:596f5ae2eeddb79b595583c2e0285312b2783b0ec759930c272dbf02f851ff75",
+                "sha256:6014038f52b4b2ac1fa41a58d439a8a00f015b5c0735a0cd4b09afe344c94899",
+                "sha256:61ebbcd208d78658b09e19c78920f1ad38936a0aa0f9c459c46c197d11c580a0",
+                "sha256:6213713ac743b190ecbf3f316d6e41d099e774812d470422b3a0f137ea635832",
+                "sha256:637e27ea1ebe4a561db75a880ac659ff439dec7f55588212e71700bb1ddd5af9",
+                "sha256:6aa427c55a0abec450bca10b64446331b5ca8f79b648531138f357569705bc4a",
+                "sha256:6ca45359d7a21644793de0e29de497ef7f1ae7268e346c4faf87b421fea364e6",
+                "sha256:6db1b52c6f2c04fafc8da17ea506608e6be7086715dab498570c3e55e4f8fbd1",
+                "sha256:752e7ddfb743344d447367baa85bccd3629c2c3940f70506eb5f01abce98ee68",
+                "sha256:760c54ad1b8a9b81951030a7e8e7c3ec0964c1cb9fee585a03ff53d9e531bb8e",
+                "sha256:768632fd8172ae03852e3245f11c8a425d95f65ff444ce46b3e673ae5b057b74",
+                "sha256:7a0b9f6a1a15d494b35f25ed07abda03209fa76c33564c09c9e81d34f4b919d7",
+                "sha256:7e070d3aef50ac3856f2ef5ec7214798453da878bb5e5a16c16a61edf1817cc3",
+                "sha256:7e12949e5071c20ec49ef00c75121ed2b076972132fc1913ddf5f76cae8d10b4",
+                "sha256:7e26eac9e52e8ce86f915fd33380f1b6896a2b51994e40bb094841e5003429b4",
+                "sha256:85ffd6b1cb0dfb037ede50ff3bef80d9bf7fa60515d192403af6745524524f3b",
+                "sha256:8618d9213a863c468a865e9d2ec50221015f7abf52221bc927152ef26c484b4c",
+                "sha256:8acef4d8a4353f6678fd1035422a937c2170de58a2b29f7da045d5249e934101",
+                "sha256:8d2f355a951f60f0843f2368b39970e4667517e54e86b1508e76f92b44811a8a",
+                "sha256:90b6840b6448203228a9d8464a7a0d99aa8fa9f027ef95fe230579abaf8a6ee1",
+                "sha256:9187500d83fd0cef4669385cbb0961e227a41c0c9bc39219044e35810793edf7",
+                "sha256:93c20777a72cae8620203ac11c4010365706062aa13aaedd1a21bb07adbb9d5d",
+                "sha256:93cce7d422a0093cfb3606beae38a8e47a25232eea0f292c878af580a9dc7605",
+                "sha256:94c623c331a48a5ccc7d25271399aff29729fa202c737ae3b4b28b89d2b0976d",
+                "sha256:97f32dc03a8054a4c4a5ab5d761ed4861e828b2c200febd4e46857069a483916",
+                "sha256:9a2bf98ac92f58777c0fafc772bf0493e67fcf677302e0c0a630ee517a43b949",
+                "sha256:a602bdc8607c99eb5b391592d58c92618dcd1537fdd87df1813f03fed49957a6",
+                "sha256:a9d24b03daf7415f78abc2d25a208f234e2c585e5e6f92f0204d2ab7b9ab48e3",
+                "sha256:abfcb0ef78df0ee9df4ea81f03beea41849340ce33a4c4bd4dbb99e23ec781b6",
+                "sha256:b013f759cd69cb0a62de954d6d2096d648bc210034b79b1881406b07ed0a83f9",
+                "sha256:b02e3e72665cd02afafb933453b0c9f6c59ff6e3708bd28d0d8580450e7e88af",
+                "sha256:b52cc45e71657bc4743a5606d9023459de929b2a198d545868e11898ba1c3f59",
+                "sha256:ba37f11e1d020969e8a779c06b4af866ffb6b854d7229db63c5fdddfceaa917f",
+                "sha256:bb804c7d0bfbd7e3f33924ff49757de9106c44e27979e2492819c16972ec0da2",
+                "sha256:bf594cc7cc9d528338d66674c10a5b25e3cde7dd75c3e96784df8f371d77a298",
+                "sha256:c38baee6bdb7fe1b110b6b3aaa555e6e872d322206b7245aa39572d3fc991ee4",
+                "sha256:c73d2166e4b210b73d1429c4f1ca97cea9cc090e5302df2a7a0a96ce55373f1c",
+                "sha256:c9099bf89078675c372339011ccfc9ec310310bf6c292b413c013eb90ffdcafc",
+                "sha256:cf0db26a1f76aa6b3aa314a74b8facd586b7a5457d05b64f8082a62c9c49582a",
+                "sha256:d19a34f8a3429bd536996ad53597b805c10352a8561d8382e05830df389d2b43",
+                "sha256:da80047524eac2acf7c04c18ac7a7da05a9136241f642dd2ed94269ef0d0a45a",
+                "sha256:de2923886b5d3214be951bc2ce3f6b8ac0d6dfd4a0d0e2a4d2e5523d8046fdfb",
+                "sha256:defa0652696ff0ba48c8aff5a1fac1eef1ca6ac9c660b047fc8e7623c4eb5093",
+                "sha256:e54a1eb9fd38f2779e973d2f8958fd575b532fe26013405d1afb9ee2374e7ab8",
+                "sha256:e5c31d70a478b0ca22a9d2d76d520ae996214019d39ed7dd93af872c7f301e52",
+                "sha256:ebaeb93f90c0903233b11ce913a7cb8f6ee069158406e056f884854c737d2442",
+                "sha256:ecfe51abf7f045e0b9cdde71ca9e153d11238679ef7b5da6c82093874adf3338",
+                "sha256:f99112aed4fb7cee00c7f77e8b964a9b10f69488cdff626ffd797d02e2e4484f",
+                "sha256:fd914db437ec25bfa410f8aa0aa2f3ba87cdfc04d9919d608d02330947afaeab"
+            ],
+            "version": "==2022.1.18"
+        },
         "requests": {
             "hashes": [
                 "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
@@ -1059,6 +1204,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==2.27.1"
+        },
+        "requests-file": {
+            "hashes": [
+                "sha256:07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e",
+                "sha256:dfe5dae75c12481f68ba353183c53a65e6044c923e64c24b2209f6c7570ca953"
+            ],
+            "version": "==1.5.1"
         },
         "rsa": {
             "hashes": [
@@ -1070,11 +1222,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:4fc7960a82c95d906a0514cf4d9aacba1743eb9863a5b7c2a01c525a7d9b21e6",
-                "sha256:f7e54567937ebcbe938c4df1075ec891587faeb7c74184b88cf2894e47c86116"
+                "sha256:141da032f0fa4c56f9af6b361fda57360af1789576285bd1944561f9c274f9c0",
+                "sha256:9aeff2a47f4038460296b920bf4d269284e8454e1c67547ee002ccafd9c2442b"
             ],
             "index": "pypi",
-            "version": "==1.5.4"
+            "version": "==1.5.3"
         },
         "setuptools": {
             "hashes": [
@@ -1197,6 +1349,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==8.0.13"
+        },
+        "tldextract": {
+            "hashes": [
+                "sha256:d2034c3558651f7d8fdadea83fb681050b2d662dc67a00d950326dc902029444",
+                "sha256:f55e05f6bf4cc952a87d13594386d32ad2dd265630a8bdfc3df03bd60425c6b0"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.1.2"
         },
         "tqdm": {
             "hashes": [

--- a/app/lang_detection.py
+++ b/app/lang_detection.py
@@ -52,7 +52,7 @@ class LangDetection:
 
         return None
 
-    def get_locale(self, text, lang, language_preferences, variant_preferences):
+    def get_locale(self, text, lang = "auto", language_preferences = None, variant_preferences = None):
         if lang == "auto":
             langs = self.predict_lang(text)
 

--- a/app/main.py
+++ b/app/main.py
@@ -184,7 +184,11 @@ async def exception(
 ):
     configure_sentry(request, id)
 
-    raise HTTPException(status_code=500, detail=user_request_in.text)
+    raise_exception(user_request_in.text)
+
+
+def raise_exception(text):
+    raise Exception()
 
 
 @app.get("/lt")

--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,7 @@ from app.settings import get_settings
 from app.logger import set_up_logger
 from app.redis import set_up_redis
 from app.languagetool import get_languagetool_url
+from app.persidio import Persidio
 from app.model import model
 from app.rules import *
 
@@ -191,6 +192,12 @@ def raise_exception(text):
     raise Exception()
 
 
+@app.post("/pii", response_model=Result)
+def get_lt(user_request_in: RequestIn, username: str = Depends(get_current_username)):
+    persidio = Persidio()
+    return Result.factory(persidio.clean_str(user_request_in.text), "scrubbed PII data")
+
+
 @app.get("/lt")
 def get_lt(username: str = Depends(get_current_username)):
     return languagetool_url
@@ -209,12 +216,12 @@ def openapi(username: str = Depends(get_current_username)):
 # public routes
 @app.get("/")
 def root():
-    url="https://www.witty.works/form"
-    status_code=301
+    url = "https://www.witty.works/form"
+    status_code = 301
 
     if settings.platform_environment == "local" and settings.testing == False:
-        url="/docs"
-        status_code=302
+        url = "/docs"
+        status_code = 302
 
     return RedirectResponse(url=url, status_code=status_code)
 
@@ -258,7 +265,9 @@ async def check_query(
 
     if locale == None:
         response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-        return Result.factory("Language could not be determined")
+        return Result.factory(
+            "Language could not be determined", "value_error.not_supported"
+        )
 
     lang = Language(locale)
 

--- a/app/models.py
+++ b/app/models.py
@@ -392,8 +392,9 @@ class ResultOut(BaseModel):
 
 class Result(BaseModel):
     detail: List
+    type: str
 
-    def factory(detail):
+    def factory(detail, type):
         detail = [
             {
                 "loc": [
@@ -401,16 +402,17 @@ class Result(BaseModel):
                     "text",
                 ],
                 "msg": detail,
-                "type": "value_error.not_supported",
+                "type": type,
             }
         ]
 
-        return Result(detail)
+        return Result(detail, type)
 
     factory = staticmethod(factory)
 
-    def __init__(self, detail):
+    def __init__(self, detail, type):
         object.__setattr__(self, "detail", detail)
+        object.__setattr__(self, "type", type)
 
 
 class ResultsOut(BaseModel):
@@ -418,7 +420,7 @@ class ResultsOut(BaseModel):
     language: str
     limit_reached: bool
 
-    def factory(results, lang, limit_reached = False):
+    def factory(results, lang, limit_reached=False):
         if lang != None:
             lang = lang.lang
 

--- a/app/persidio.py
+++ b/app/persidio.py
@@ -1,0 +1,75 @@
+from presidio_analyzer import AnalyzerEngine, PatternRecognizer, Pattern
+from presidio_analyzer.nlp_engine import SpacyNlpEngine
+from presidio_anonymizer import AnonymizerEngine
+from app.lang_detection import LangDetection
+from app.model import model
+
+
+class LoadedSpacyNlpEngine(SpacyNlpEngine):
+    def __init__(self, loaded_spacy_models):
+        self.nlp = loaded_spacy_models
+
+
+class Persidio:
+    def __init__(self):
+        self.lang_detection = LangDetection()
+
+        # @TODO limit to just "words" containing only digits
+        numbers_pattern = Pattern(name="numbers_pattern", regex="\d+", score=0.5)
+        number_recognizer = PatternRecognizer(
+            supported_entity="NUMBER", patterns=[numbers_pattern]
+        )
+
+        # @TODO limit to just "words" containing only digits and upper case letters
+        cryptic_text_pattern = Pattern(
+            name="cryptic_text_pattern", regex="A-Z\d+", score=0.5
+        )
+        cryptic_text_recognizer = PatternRecognizer(
+            supported_entity="CRYPTIC_TEXT", patterns=[cryptic_text_pattern]
+        )
+
+        self.analyzer = AnalyzerEngine(
+            nlp_engine=LoadedSpacyNlpEngine(loaded_spacy_models=model),
+            supported_languages=model.keys(),
+        )
+        self.analyzer.registry.add_recognizer(number_recognizer)
+        self.analyzer.registry.add_recognizer(cryptic_text_recognizer)
+
+        self.anonymizer = AnonymizerEngine()
+
+    def clean_str(self, text: str):
+        try:
+            locale = self.lang_detection.get_locale(text)
+            if locale:
+                lang = locale[0:2]
+            else:
+                lang = "en"
+
+            results = self.analyzer.analyze(text=text, language=lang)
+
+            result = self.anonymizer.anonymize(text=text, analyzer_results=results)
+
+            return result.text
+        except:
+            pass
+
+        return "-- unable to anonymize --"
+
+    def clean_dict(self, dict):
+        for dict_key in dict.keys():
+            dict[dict_key] = self.clean_var(dict[dict_key])
+
+        return dict
+
+    def clean_var(self, var):
+        if isinstance(var, str):
+            var = self.clean_str(var)
+
+        if isinstance(var, dict):
+            var = self.clean_dict(var)
+
+        if isinstance(var, list):
+            for key in range(len(var)):
+                var[key] = self.clean_var(var[key])
+
+        return var

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,20 +1,42 @@
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
+from app.persidio import Persidio
+
+
+def sentry_clean_sensitive_frame(frame, persidio: Persidio):
+    for var_name in frame.get("vars", None):
+        frame["vars"][var_name] = persidio.clean_var(frame["vars"][var_name], persidio)
+
+    return frame
+
+
+def sentry_clean_event_data(event, hint):
+    persidio = Persidio
+
+    for exception in event.get("exception", {}).get("values", []):
+        for frame in exception.get("stacktrace", {}).get("frames", []):
+            frame = sentry_clean_sensitive_frame(frame, persidio)
+
+    for exception in event.get("threads", {}).get("values", []):
+        for frame in exception.get("stacktrace", {}).get("frames", []):
+            frame = sentry_clean_sensitive_frame(frame, persidio)
+
+    return event
+
 
 # Sentry SDK set up
 def set_up_sentry_sdk(version, settings):
     if not settings.sentry_dsn or settings.testing == True:
         return None
 
-    integrations = [AioHttpIntegration()]
-
     sentry_sdk.init(
         dsn=settings.sentry_dsn,
         traces_sample_rate=settings.sentry_traces_sample_rate,
         sample_rate=settings.sentry_sample_rate,
-        integrations=integrations,
+        integrations=[AioHttpIntegration()],
         release=version,
         environment=settings.platform_environment,
+        before_send=sentry_clean_event_data,
     )
 
     return sentry_sdk

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -217,7 +217,6 @@ def test_language_detection_fail(fails_case_dir, snapshot):
     snapshot.assert_match(output, "output.json")
 
 
-
 def test_categories():
     response = client.get("/categories")
     assert response.status_code == 200
@@ -407,3 +406,24 @@ def test_store_rules():
         "en-US",
         "de-DE",
     ]
+
+
+# test PII scrubbing
+
+
+@pytest.mark.parametrize(
+    "pii_scrubbing_case_dir",
+    get_dirs("tests/test_pii_scrubbing"),
+)
+def test_pii_scrubbing(pii_scrubbing_case_dir, snapshot):
+
+    # Read input files from the case directory.
+    input_json = pii_scrubbing_case_dir.joinpath("input.json").read_text()
+    # Call the tested endpoint.
+    response = client.post("/pii", json=json.loads(input_json))
+    assert response.status_code == 200
+    # output must be string
+    output = json.dumps(response.json(), sort_keys=True, indent=4, ensure_ascii=False)
+    # Snapshot the return value.
+    snapshot.snapshot_dir = pii_scrubbing_case_dir
+    snapshot.assert_match(output, "output.json")

--- a/tests/test_fails/test_language_detection_not_supported/output.json
+++ b/tests/test_fails/test_language_detection_not_supported/output.json
@@ -8,5 +8,6 @@
             "msg": "Language could not be determined",
             "type": "value_error.not_supported"
         }
-    ]
+    ],
+    "type": "value_error.not_supported"
 }

--- a/tests/test_pii_scrubbing/test_english_text/input.json
+++ b/tests/test_pii_scrubbing/test_english_text/input.json
@@ -1,0 +1,3 @@
+{
+    "text": "Hello, I am David (23) and you can reach me under +41774261811 and here is my API key 23S76D23S335LW"
+}

--- a/tests/test_pii_scrubbing/test_english_text/output.json
+++ b/tests/test_pii_scrubbing/test_english_text/output.json
@@ -1,0 +1,13 @@
+{
+    "detail": [
+        {
+            "loc": [
+                "body",
+                "text"
+            ],
+            "msg": "Hello, I am <PERSON> (<NUMBER>) and you can reach me under <PHONE_NUMBER> and here is my API key <NUMBER>S<NUMBER>D<NUMBER>S<NUMBER>LW",
+            "type": "scrubbed PII data"
+        }
+    ],
+    "type": "scrubbed PII data"
+}

--- a/tests/test_pii_scrubbing/test_german_text/input.json
+++ b/tests/test_pii_scrubbing/test_german_text/input.json
@@ -1,0 +1,3 @@
+{
+    "text": "Hallo, Ich bin David (23) und du kannst mich unter 0774261811 erreichen und hier ist mein API Schlüssel API key 23S76D23S335LW."
+}

--- a/tests/test_pii_scrubbing/test_german_text/output.json
+++ b/tests/test_pii_scrubbing/test_german_text/output.json
@@ -1,0 +1,13 @@
+{
+    "detail": [
+        {
+            "loc": [
+                "body",
+                "text"
+            ],
+            "msg": "Hallo, Ich bin <PERSON> (23) und du kannst mich unter <PHONE_NUMBER> erreichen und hier ist mein API Schlüssel API key 23S76D23S335LW.",
+            "type": "scrubbed PII data"
+        }
+    ],
+    "type": "scrubbed PII data"
+}


### PR DESCRIPTION
fixes #297

https://presidio-demo.azurewebsites.net/
https://microsoft.github.io/presidio/analyzer/

This implementation works fine but note the list of supported entities is limited:
https://microsoft.github.io/presidio/supported_entities/

see also https://www.notion.so/witty-works/Privacy-vs-Data-Collection-1dbf896818cf4067a8b932a4e3163829

example see https://sentry.io/organizations/witty-works/issues/2975885227/?environment=local&project=5991571&query=is%3Aunresolved

consider adding additional regexp:
* [ ] remove all numbers "words" (ie. `\s\d+\s`)
* [ ] remove all words with only numbers and uppercase letters (ie. `\s[\dA-Z]+\s`)
* [x] https://github.com/microsoft/presidio/issues/822