### PR TITLE
transform word to lowcase english

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -634,7 +634,7 @@ def EnglishRules(lang, tokens, user_request_in: RequestIn):
         sentences_alternatives_en["style"] = style_sentences_alternatives_US
         sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
     if IsSubCategoryEnabled("openly_discriminating", disabled_categories):
-        list_full += RulesBasedWordsPhraseMatcherUN(
+        list_full += RulesBasedWordsPhraseMatcherEN(
             user_request_in.config,
             lang,
             user_request_in.text,
@@ -646,7 +646,7 @@ def EnglishRules(lang, tokens, user_request_in: RequestIn):
         )
 
     if IsSubCategoryEnabled("gendered", disabled_categories):
-        list_full += RulesBasedWordsPhraseMatcherUN(
+        list_full += RulesBasedWordsPhraseMatcherEN(
             user_request_in.config,
             lang,
             user_request_in.text,
@@ -677,7 +677,7 @@ def EnglishRules(lang, tokens, user_request_in: RequestIn):
         )
 
     if IsSubCategoryEnabled("style", disabled_categories):
-        list_full += RulesBasedWordsPhraseMatcherUN(
+        list_full += RulesBasedWordsPhraseMatcherEN(
             user_request_in.config,
             lang,
             user_request_in.text,
@@ -689,7 +689,7 @@ def EnglishRules(lang, tokens, user_request_in: RequestIn):
         )
 
     if IsSubCategoryEnabled("unconscious_bias", disabled_categories):
-        list_full += RulesBasedWordsPhraseMatcherUN(
+        list_full += RulesBasedWordsPhraseMatcherEN(
             user_request_in.config,
             lang,
             user_request_in.text,
@@ -718,6 +718,15 @@ def IsItFalsePositive(word, false_positive):
             return True
 
     return False
+
+
+"""Function to make transform words to lowcase used for English"""
+
+
+def GetLowerCased(token):
+    token_word = token.lemma_
+
+    return token_word.lower()
 
 
 """Function to catch ending in German Denom"""
@@ -1298,8 +1307,8 @@ def MisgenderingInstitutionsDE(config: Config, lang, full_text, tokens):
     return db_match_list
 
 
-# Unified function English&German
-def RulesBasedWordsPhraseMatcherUN(
+# function English
+def RulesBasedWordsPhraseMatcherEN(
     config: Config,
     lang,
     full_text,
@@ -1319,7 +1328,7 @@ def RulesBasedWordsPhraseMatcherUN(
 
     for token in tokens:
         for word, alternative, subcategory in words_alternatives:
-            if token.lemma_ == word:
+            if GetLowerCased(token) == word:
                 list_tokens.append(
                     ResultOut.factory(
                         config,
@@ -1371,7 +1380,7 @@ def GenderedEN(
             alternative_plur,
             subcategory,
         ) in gendered_words_alternatives:
-            if token.lemma_ == word:
+            if GetLowerCased(token) == word:
                 token_morph_number = token.morph.get("Number")
                 if is_number_list_empty(token_morph_number, token):
                     continue
@@ -1431,7 +1440,7 @@ def RulesBasedWordsPhraseMatcherNoAltEN(
 
     for token in tokens:
         for word, subcategory in inclusive_words_alternatives_en:
-            if token.lemma_ == word:
+            if GetLowerCased(token) == word:
                 list_tokens.append(
                     ResultOut.factory(
                         config,

--- a/tests/test_sentry_examples/test_english_morph_token/output.json
+++ b/tests/test_sentry_examples/test_english_morph_token/output.json
@@ -46,6 +46,42 @@
             "start": 134,
             "subcategory": "orthography",
             "text": "Riehenring"
+        },
+        {
+            "alternatives": [
+                "They",
+                "Heads",
+                "Person who supports and motivates the team",
+                "Someone who comunicates a shared vision",
+                "Someone who helps identify milestones",
+                "Person who offers guidance",
+                "Person who takes a coaching role to help a team work toward shared goals"
+            ],
+            "category": "gendered",
+            "context": "Hi Siwar,\n\nit's the first time that we are looking for a intern\nThomas Jung\nHead of Talent Acquisition EMEA\n\nFossil Group Europe GmbH\nRiehenring 182\n\n4058 Basel\nSWITZERLAND\nwww.fos",
+            "end": 80,
+            "label": "Gendered: Leadership stereotype",
+            "reason": "Casts the topic of leadership in stereotypical male terms and traditionally hierarchical.",
+            "solution": "Use terms that assume a supportive notion of leadership and can mean different genders.",
+            "start": 76,
+            "subcategory": "leadership",
+            "text": "Head"
+        },
+        {
+            "alternatives": [
+                "Older person",
+                "Adult",
+                "Retiree"
+            ],
+            "category": "unconscious_bias",
+            "context": "\n\nit's the first time that we are looking for a intern\nThomas Jung\nHead of Talent Acquisition EMEA\n\nFossil Group Europe GmbH\nRiehenring 182\n\n4058 Basel\nSWITZERLAND\nwww.fossilgroup.com\nt: +41 61 560 99 69\nm:",
+            "end": 115,
+            "label": "Biased language: 50 years and older",
+            "reason": "Outdated hidden or even discriminatory wording pigeonholing people 50 years or older.",
+            "solution": "Ask yourself \"What would I write if this person was 35 years old?\"",
+            "start": 109,
+            "subcategory": "age_old",
+            "text": "Fossil"
         }
     ]
 }


### PR DESCRIPTION
- Add GetLowerCased for English rules. Sometimes SpaCy struggle with lemmatisation of the words with capital letter and either transform them also to capital letter either transform them to not the right form of the word. To avoid this the function GetLowerCased for English rules was added. This issue related to [283](https://github.com/witty-works/nlp_api/issues/283), which was not completely resolved with stripe(). And also now it highlights "Head" in this dirty text "Thomas Jung\nHead of Talent Acquisition EMEA\n\nFossil Group Europe GmbH\nRiehenring 182\n\n4058 Basel\nSWITZERLAND"
- fix test correspondently 