### PR TITLE
for local dev, do a 302 redirect to docs instead of the hubspot form

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -204,13 +204,20 @@ def openapi(username: str = Depends(get_current_username)):
 
 # public routes
 @app.get("/")
-def get_root():
-    return RedirectResponse(url="https://www.witty.works/form", status_code=301)
+def root():
+    url="https://www.witty.works/form"
+    status_code=301
+
+    if settings.platform_environment == "local" and settings.testing == False:
+        url="/docs"
+        status_code=302
+
+    return RedirectResponse(url=url, status_code=status_code)
 
 
 @app.get("/form")
-def form(request: Request):
-    return RedirectResponse(url="https://www.witty.works/form", status_code=301)
+def form():
+    return root()
 
 
 @app.get("/categories")


### PR DESCRIPTION
I mostly just wanted to prevent the 301 locally since its cached and is a bit annoying if you sometimes also run something else locally on port 8000 .. but it also makes sense to redirect to `/docs` as well since that is the more relevant endpoint locally.