### PR TITLE
integrate LT categories as subcategories

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -422,6 +422,20 @@ def languagetool_matches(
                 value = value if value != "" else "-"
                 alternatives.append(value)
 
+        label = match["shortMessage"]
+        if label == "":
+            try:
+                label = match["rule"]["category"]["name"]
+            except KeyError:
+                pass
+
+        try:
+            subcategory = match["rule"]["category"]["id"].lower()
+        except KeyError:
+            subcategory = category
+
+        explanation = match["message"]
+
         list_results.append(
             ResultOut.factory(
                 version,
@@ -430,12 +444,12 @@ def languagetool_matches(
                 highlight_text,
                 text,
                 category,
-                category,
+                subcategory,
                 offset,
                 end,
                 alternatives,
-                match["shortMessage"],
-                match["message"],
+                label,
+                explanation,
             )
         )
 
@@ -495,11 +509,9 @@ async def language_rules(version: float, config: Config, lang: Language, text: s
 
     if is_sub_category_enabled(config, "orthography"):
         try:
-            languagetools_results = await languagetool_rules(
-                version, config, lang, text
-            )
-            list_results = languagetools_results + list_results
-        except:
+            languagetool_results = await languagetool_rules(version, config, lang, text)
+            list_results = languagetool_results + list_results
+        except Exception:
             pass
 
     return list_results

--- a/app/main.py
+++ b/app/main.py
@@ -468,6 +468,16 @@ async def languagetool_rules(version: float, config: Config, lang: Language, tex
             "motherTongue": config.primary_language,
         }
 
+        spelling_categories = list(
+            set(config.disabled_categories) - set(categories.keys())
+        )
+
+        if len(spelling_categories) > 0:
+            spelling_categories = [
+                spelling_category.upper() for spelling_category in spelling_categories
+            ]
+            payload["disabledCategories"] = spelling_categories
+
         async with session.post(languagetool_url + "/check", data=payload) as r:
             try:
                 assert r.status == 200

--- a/app/models.py
+++ b/app/models.py
@@ -315,7 +315,7 @@ class ResultOut(BaseModel):
 
         label = label if label else lang._("rules." + category + "_label")
         if category != "orthography":
-            trans_key = subcategory
+            category_key = subcategory
 
             settings = get_settings()
             url = (
@@ -329,31 +329,31 @@ class ResultOut(BaseModel):
             )
         else:
             url = None
-            trans_key = category
+            category_key = category
 
-        if category != trans_key:
-            label += ": " + lang._("rules." + trans_key + "_label")
+        if category != category_key:
+            label += ": " + lang._("rules." + category_key + "_label")
 
-        reason = lang._("rules." + trans_key + "_reason", params)
+        reason = lang._("rules." + category_key + "_reason", params)
         solution = explanation
         solution = (
             solution
             if solution != None
-            else lang._("rules." + trans_key + "_solution", params)
+            else lang._("rules." + category_key + "_solution", params)
         )
 
         if explanation != None:
             icon, explanation = ResultOut.parseExplanation(explanation)
             if icon == None:
                 icon, foo = ResultOut.parseExplanation(
-                    lang._("rules." + trans_key + "_explanation", params)
+                    lang._("rules." + category_key + "_explanation", params)
                 )
         else:
             icon, explanation = ResultOut.parseExplanation(
-                lang._("rules." + trans_key + "_explanation", params)
+                lang._("rules." + category_key + "_explanation", params)
             )
 
-        gravity = gravity if gravity != None else categories[trans_key]["gravity"]
+        gravity = gravity if gravity != None else categories[category_key]["gravity"]
 
         is_upper = text[0:1].isupper()
 
@@ -452,7 +452,7 @@ class ResultOut(BaseModel):
                 text=text,
                 context=context,
                 category=category,
-                subcategory=trans_key,
+                subcategory=subcategory,
                 start=start,
                 end=end,
                 alternatives=list(cleaned_alternatives.values()),

--- a/app/models.py
+++ b/app/models.py
@@ -314,29 +314,9 @@ class ResultOut(BaseModel):
             params["gendered_denominations_ending"] = config.german_gender_ending
 
         label = label if label else lang._("rules." + category + "_label")
-        if category != subcategory:
-            label += ": " + lang._("rules." + subcategory + "_label")
-
-        reason = lang._("rules." + subcategory + "_reason", params)
-        solution = explanation
-        solution = (
-            solution
-            if solution != None
-            else lang._("rules." + subcategory + "_solution", params)
-        )
-
-        if explanation != None:
-            icon, explanation = ResultOut.parseExplanation(explanation)
-            if icon == None:
-                icon, foo = ResultOut.parseExplanation(
-                    lang._("rules." + subcategory + "_explanation", params)
-                )
-        else:
-            icon, explanation = ResultOut.parseExplanation(
-                lang._("rules." + subcategory + "_explanation", params)
-            )
-
         if category != "orthography":
+            trans_key = subcategory
+
             settings = get_settings()
             url = (
                 settings.learning_bites_base_url
@@ -349,8 +329,31 @@ class ResultOut(BaseModel):
             )
         else:
             url = None
+            trans_key = category
 
-        gravity = gravity if gravity != None else categories[subcategory]["gravity"]
+        if category != trans_key:
+            label += ": " + lang._("rules." + trans_key + "_label")
+
+        reason = lang._("rules." + trans_key + "_reason", params)
+        solution = explanation
+        solution = (
+            solution
+            if solution != None
+            else lang._("rules." + trans_key + "_solution", params)
+        )
+
+        if explanation != None:
+            icon, explanation = ResultOut.parseExplanation(explanation)
+            if icon == None:
+                icon, foo = ResultOut.parseExplanation(
+                    lang._("rules." + trans_key + "_explanation", params)
+                )
+        else:
+            icon, explanation = ResultOut.parseExplanation(
+                lang._("rules." + trans_key + "_explanation", params)
+            )
+
+        gravity = gravity if gravity != None else categories[trans_key]["gravity"]
 
         is_upper = text[0:1].isupper()
 
@@ -449,7 +452,7 @@ class ResultOut(BaseModel):
                 text=text,
                 context=context,
                 category=category,
-                subcategory=subcategory,
+                subcategory=trans_key,
                 start=start,
                 end=end,
                 alternatives=list(cleaned_alternatives.values()),

--- a/tests/test_1_0/test_api/input.json
+++ b/tests/test_1_0/test_api/input.json
@@ -1,5 +1,5 @@
 {
-    "text": "Wir suchen Ninja Programmierer für unsere Kunden",
+    "text": "Wir suchen Ninja Programmierer für unseere Kunden",
     "config": {
         "store_context": false
     }

--- a/tests/test_1_0/test_api/output.json
+++ b/tests/test_1_0/test_api/output.json
@@ -28,7 +28,7 @@
             "reason": "Korrigieren sie eventuelle Rechtschreib- oder Grammatikfehler, um die Wirkung ihrer Texte zu maximieren.",
             "solution": "Möglicher Tippfehler gefunden.",
             "start": 35,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "unseere"
         },
         {

--- a/tests/test_1_0/test_api/output.json
+++ b/tests/test_1_0/test_api/output.json
@@ -4,6 +4,35 @@
     "results": [
         {
             "alternatives": [
+                "unsere",
+                "unserer",
+                "untere",
+                "unser",
+                "unserem",
+                "unseren",
+                "unseres",
+                "unitäre",
+                "unserm",
+                "unsern",
+                "unsre",
+                "unsrer",
+                "unstete",
+                "ansäuere",
+                "ansäure",
+                "unterere"
+            ],
+            "category": "orthography",
+            "context": "",
+            "end": 42,
+            "label": "Rechtschreibfehler",
+            "reason": "Korrigieren sie eventuelle Rechtschreib- oder Grammatikfehler, um die Wirkung ihrer Texte zu maximieren.",
+            "solution": "Möglicher Tippfehler gefunden.",
+            "start": 35,
+            "subcategory": "orthography",
+            "text": "unseere"
+        },
+        {
+            "alternatives": [
                 "Jemand, der erfahren und fachkundig ist",
                 "Jemand mit Know-how und Erfahrung",
                 "Mensch, der seine Fachkenntnis ständig vertieft"
@@ -31,11 +60,11 @@
             ],
             "category": "gendered",
             "context": "",
-            "end": 48,
+            "end": 49,
             "label": "Geschlechtsspezifisch: Titel",
             "reason": "Das männliche Generikum spricht nicht alle Geschlechter oder Geschlechtsidentitäten an. Viele Menschen fühlen sich daher nicht in den Dialog einbezogen.",
             "solution": "Verwenden Sie eine Schreibweise, die das weibliche Geschlecht sowie auch andere Geschlechteridentitäten, die nicht einem binären Verständnis von Geschlecht folgen, anspricht.",
-            "start": 42,
+            "start": 43,
             "subcategory": "titles",
             "text": "Kunden"
         }

--- a/tests/test_demo_wordings_english/test_internal_email/output.json
+++ b/tests/test_demo_wordings_english/test_internal_email/output.json
@@ -16,9 +16,9 @@
                 "text": "Use a comma before ‘and’ if it connects two independent clauses (unless they are closely connected and short)."
             },
             "gravity": 1,
-            "label": "Orthography",
+            "label": "Punctuation",
             "start": 92,
-            "subcategory": "orthography",
+            "subcategory": "punctuation",
             "text": " and"
         },
         {

--- a/tests/test_demo_wordings_german/test_internal_email/output.json
+++ b/tests/test_demo_wordings_german/test_internal_email/output.json
@@ -16,9 +16,9 @@
                 "text": "Außer am Satzanfang werden nur Nomen und Eigennamen großgeschrieben."
             },
             "gravity": 1,
-            "label": "Orthographie",
+            "label": "Groß-/Kleinschreibung",
             "start": 22,
-            "subcategory": "orthography",
+            "subcategory": "casing",
             "text": "Wir"
         },
         {
@@ -94,7 +94,7 @@
             "gravity": 1,
             "label": "Rechtschreibfehler",
             "start": 168,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "Grüsse"
         },
         {

--- a/tests/test_demo_wordings_german/test_website_short_sentences_example3/output.json
+++ b/tests/test_demo_wordings_german/test_website_short_sentences_example3/output.json
@@ -42,7 +42,7 @@
             "gravity": 1,
             "label": "Rechtschreibfehler",
             "start": 10,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "aussergewöhnliche"
         },
         {

--- a/tests/test_general_cases/test_api_gravity/output.json
+++ b/tests/test_general_cases/test_api_gravity/output.json
@@ -68,7 +68,7 @@
             "gravity": 1,
             "label": "Rechtschreibfehler",
             "start": 4,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "suchn"
         },
         {

--- a/tests/test_highlight_position/test_line_break_counting/output.json
+++ b/tests/test_highlight_position/test_line_break_counting/output.json
@@ -16,9 +16,9 @@
                 "text": "This sentence does not start with an uppercase letter."
             },
             "gravity": 1,
-            "label": "Orthography",
+            "label": "Capitalization",
             "start": 2,
-            "subcategory": "orthography",
+            "subcategory": "casing",
             "text": "helo"
         },
         {

--- a/tests/test_language_detection/test_language_detection_german/output.json
+++ b/tests/test_language_detection/test_language_detection_german/output.json
@@ -15,9 +15,9 @@
                 "text": "Dieser Satz fängt nicht mit einem großgeschriebenen Wort an."
             },
             "gravity": 1,
-            "label": "Orthographie",
+            "label": "Groß-/Kleinschreibung",
             "start": 0,
-            "subcategory": "orthography",
+            "subcategory": "casing",
             "text": "liebe"
         },
         {
@@ -92,7 +92,7 @@
             "gravity": 1,
             "label": "Rechtschreibfehler",
             "start": 6,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "mensch"
         },
         {

--- a/tests/test_orthography/test_api_orthography_disabled_category/input.json
+++ b/tests/test_orthography/test_api_orthography_disabled_category/input.json
@@ -1,0 +1,9 @@
+{
+    "text": "what is going on?",
+    "config": {
+        "store_context": false,
+        "disabled_categories": [
+            "casing"
+        ]
+    }
+}

--- a/tests/test_orthography/test_api_orthography_disabled_category/output.json
+++ b/tests/test_orthography/test_api_orthography_disabled_category/output.json
@@ -1,0 +1,5 @@
+{
+    "language": "en",
+    "limit_reached": false,
+    "results": []
+}

--- a/tests/test_orthography/test_api_orthography_english/input.json
+++ b/tests/test_orthography/test_api_orthography_english/input.json
@@ -1,5 +1,5 @@
 {
-    "text": "I liki all the colors",
+    "text": "I liki all the colors. what is going on?",
     "config": {
         "store_context": false
     }

--- a/tests/test_orthography/test_api_orthography_english/output.json
+++ b/tests/test_orthography/test_api_orthography_english/output.json
@@ -37,6 +37,24 @@
             "start": 2,
             "subcategory": "typos",
             "text": "liki"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "What"
+                }
+            ],
+            "category": "orthography",
+            "end": 27,
+            "explanation": {
+                "icon": "❌",
+                "text": "This sentence does not start with an uppercase letter."
+            },
+            "gravity": 1,
+            "label": "Capitalization",
+            "start": 23,
+            "subcategory": "casing",
+            "text": "what"
         }
     ]
 }

--- a/tests/test_orthography/test_api_orthography_english/output.json
+++ b/tests/test_orthography/test_api_orthography_english/output.json
@@ -35,7 +35,7 @@
             "gravity": 1,
             "label": "Spelling mistake",
             "start": 2,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "liki"
         }
     ]

--- a/tests/test_orthography/test_api_orthography_german/output.json
+++ b/tests/test_orthography/test_api_orthography_german/output.json
@@ -74,7 +74,7 @@
             "gravity": 1,
             "label": "Rechtschreibfehler",
             "start": 22,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "ueber"
         },
         {
@@ -149,7 +149,7 @@
             "gravity": 1,
             "label": "Rechtschreibfehler",
             "start": 32,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "Strasse"
         },
         {
@@ -165,9 +165,9 @@
                 "text": "Die Verwendung von mehreren Frage- oder Ausrufezeichen wirkt oft übertrieben emphatisch."
             },
             "gravity": 1,
-            "label": "Orthographie",
+            "label": "Zeichensetzung",
             "start": 39,
-            "subcategory": "orthography",
+            "subcategory": "punctuation",
             "text": "!!!"
         }
     ]

--- a/tests/test_sentry_examples/test_english_morph_token/output.json
+++ b/tests/test_sentry_examples/test_english_morph_token/output.json
@@ -26,7 +26,7 @@
             "gravity": 1,
             "label": "Spelling mistake",
             "start": 3,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "Siwar"
         },
         {
@@ -44,7 +44,7 @@
             "gravity": 1,
             "label": "Wrong article",
             "start": 55,
-            "subcategory": "orthography",
+            "subcategory": "misc",
             "text": "a"
         },
         {
@@ -65,7 +65,7 @@
             "gravity": 1,
             "label": "Spelling mistake",
             "start": 134,
-            "subcategory": "orthography",
+            "subcategory": "typos",
             "text": "Riehenring"
         },
         {


### PR DESCRIPTION
fixes https://github.com/witty-works/nlp_api/issues/392

fundamentally this PR turns LT categories into subcategories of "orthography" so that we can also filter on them.

a side benefit of this is that it also improves the "label" in some cases.