### PR TITLE
move singular they to csv file

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -709,6 +709,10 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         words_alternatives_en["ge"] = gender_words_alternatives_GB
         words_alternatives_en["style"] = style_words_alternatives_GB
         words_alternatives_en["bias"] = bias_words_alternatives_GB
+
+        if config.singular_they == SingularThey.ALL_PRONOUNS:
+            words_alternatives_en["bias"] += bias_singular_they_alternatives_GB
+
         inclusive_words_alternatives_en = inclusive_words_alternatives_GB
         gendered_words_alternatives_en["gendered"] = gender_noun_words_alternatives_GB
         gendered_words_alternatives_en["bias"] = gender_bias_words_alternatives_GB
@@ -722,6 +726,10 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         words_alternatives_en["ge"] = gender_words_alternatives_US
         words_alternatives_en["style"] = style_words_alternatives_US
         words_alternatives_en["bias"] = bias_words_alternatives_US
+
+        if config.singular_they == SingularThey.ALL_PRONOUNS:
+            words_alternatives_en["bias"] += bias_singular_they_alternatives_US
+
         inclusive_words_alternatives_en = inclusive_words_alternatives_US
         gendered_words_alternatives_en["gendered"] = gender_noun_words_alternatives_US
         gendered_words_alternatives_en["bias"] = gender_bias_words_alternatives_US
@@ -730,10 +738,6 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         sentences_alternatives_en["ge"] = gender_sentences_alternatives_US
         sentences_alternatives_en["style"] = style_sentences_alternatives_US
         sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
-
-    if config.singular_they == SingularThey.ALL_PRONOUNS:
-        words_alternatives_en["bias"].append(("he", "['they']", "binary_pronouns"))
-        words_alternatives_en["bias"].append(("she", "['they']", "binary_pronouns"))
 
     if is_sub_category_enabled(config, "openly_discriminating"):
         list_full += rules_based_words_phrase_matcher_en(

--- a/app/rules.py
+++ b/app/rules.py
@@ -47,6 +47,7 @@ rules = {
         "df_ub_plur_word": "ub_plur_words.csv",
         "df_ub_no_plur_word": "ub_no_plur_words.csv",
         "df_ub_sentence": "ub_sentences.csv",
+        "df_ub_singular_they": "ub_singular_they.csv",
     },
 }
 
@@ -412,5 +413,23 @@ bias_sentences_alternatives_GB = list(
         df_bias_sentences_GB["Lemma"],
         df_bias_sentences_GB["Alt_split"],
         df_bias_sentences_GB["Primary_subcategory"],
+    )
+)
+
+df_bias_singular_they_US = rules["en-US"]["df_ub_singular_they"]
+df_bias_singular_they_GB = rules["en-GB"]["df_ub_singular_they"]
+# unconscious bias singular they: lemma + alternatives split + subcategory
+bias_singular_they_alternatives_US = list(
+    zip(
+        df_bias_singular_they_US["Lemma"],
+        df_bias_singular_they_US["Alt_split"],
+        df_bias_singular_they_US["Primary_subcategory"],
+    )
+)
+bias_singular_they_alternatives_GB = list(
+    zip(
+        df_bias_singular_they_GB["Lemma"],
+        df_bias_singular_they_GB["Alt_split"],
+        df_bias_singular_they_GB["Primary_subcategory"],
     )
 )

--- a/training_data/en-GB/ub_singular_they.csv
+++ b/training_data/en-GB/ub_singular_they.csv
@@ -1,0 +1,7 @@
+Lemma,Word_Type,Priority,Category,Primary_subcategory,Sg_all_split,Pl_all_split,Alt_split
+he,s,21-01-2022,unconscious_bias,binary_pronouns,['they'],[''],['they']
+she,s,21-01-2022,unconscious_bias,binary_pronouns,['they'],[''],['they']
+him,s,21-01-2022,unconscious_bias,binary_pronouns,['them'],[''],['them']
+her,s,21-01-2022,unconscious_bias,binary_pronouns,['them'],[''],['them']
+himself,s,21-01-2022,unconscious_bias,binary_pronouns,['themself'],[''],['themself']
+herself,s,21-01-2022,unconscious_bias,binary_pronouns,['themself'],[''],['themself']

--- a/training_data/en-US/ub_singular_they.csv
+++ b/training_data/en-US/ub_singular_they.csv
@@ -1,0 +1,7 @@
+Lemma,Word_Type,Priority,Category,Primary_subcategory,Sg_all_split,Pl_all_split,Alt_split
+he,s,21-01-2022,unconscious_bias,binary_pronouns,['they'],[''],['they']
+she,s,21-01-2022,unconscious_bias,binary_pronouns,['they'],[''],['they']
+him,s,21-01-2022,unconscious_bias,binary_pronouns,['them'],[''],['them']
+her,s,21-01-2022,unconscious_bias,binary_pronouns,['them'],[''],['them']
+himself,s,21-01-2022,unconscious_bias,binary_pronouns,['themself'],[''],['themself']
+herself,s,21-01-2022,unconscious_bias,binary_pronouns,['themself'],[''],['themself']


### PR DESCRIPTION
as discussed yesterday I moved the hardcoded rules to a csv file.

@lnazarenko can you then handle the pre-process script side to generate this file from the google sheet? obviously the relevant rules then also need to be added to the google sheet. or is this something that @Szarad can already handle herself?

* [x] add rules to the google sheet @lsmith77 
* [ ] add script to generate the csv file @lnazarenko 