### PR TITLE
show different alternatives for homonyms English depending on part-of-the-speach

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -773,6 +773,10 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         sentences_alternatives_en["style"] = style_sentences_alternatives_US
         sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
 
+    list_full += homonyms_english(
+        version, config, lang, text, tokens, rules[lang.locale]["df_homonyms_word"]
+    )
+
     if is_sub_category_enabled(config, "openly_discriminating"):
         list_full += rules_based_words_phrase_matcher_en(
             version,

--- a/app/main.py
+++ b/app/main.py
@@ -738,11 +738,13 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
     gendered_words_alternatives_en = defaultdict(list)
     inclusive_sentences_alternatives_en = []
     sentences_alternatives_en = defaultdict(list)
+
     if lang.locale == "en-GB":
         words_alternatives_en["od"] = open_disc_words_alternatives_GB
         words_alternatives_en["ge"] = gender_words_alternatives_GB
         words_alternatives_en["style"] = style_words_alternatives_GB
         words_alternatives_en["bias"] = bias_words_alternatives_GB
+        words_alternatives_en["homonym"] = homonyms_word_GB
 
         if config.singular_they == SingularThey.ALL_PRONOUNS:
             words_alternatives_en["ge"] += bias_singular_they_alternatives_GB
@@ -760,6 +762,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         words_alternatives_en["ge"] = gender_words_alternatives_US
         words_alternatives_en["style"] = style_words_alternatives_US
         words_alternatives_en["bias"] = bias_words_alternatives_US
+        words_alternatives_en["homonym"] = homonyms_word_US
 
         if config.singular_they == SingularThey.ALL_PRONOUNS:
             words_alternatives_en["ge"] += bias_singular_they_alternatives_US
@@ -774,7 +777,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
 
     list_full += homonyms_english(
-        version, config, lang, text, tokens, rules[lang.locale]["df_homonyms_words"]
+        version, config, lang, text, tokens, words_alternatives_en["homonym"]
     )
 
     if is_sub_category_enabled(config, "openly_discriminating"):

--- a/app/main.py
+++ b/app/main.py
@@ -1675,43 +1675,31 @@ def rules_based_words_phrase_matcher_en(
 
     return list_tokens
 
-for (
-            word,
-            alternative_sing,
-            alternative_plur,
-            subcategory,
-        ) in gendered_words_alternatives:
-
-
 
 # english function to handle homonyms
 def homonyms_english(
-    version: float,
-    config: Config,
-    lang,
-    full_text,
-    tokens,
-    homonyms_words
-    ):
+    version: float, config: Config, lang, full_text, tokens, homonyms_words
+):
 
     list_tokens = []
     for token in tokens:
-         for word, word_type, category, subcategory, alternative in homonyms_words:
-                if token.lemma_ == word and token.pos_ == type_transform(word_type):
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            ast.literal_eval(alternative),
+        for word, word_type, category, subcategory, alternative in homonyms_words:
+            if token.lemma_ == word and token.pos_ == type_transform(word_type):
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        token.text,
+                        full_text,
+                        category,
+                        subcategory,
+                        token.idx,
+                        token.idx + len(token.text),
+                        ast.literal_eval(alternative),
                     )
-            
+                )
+    return list_tokens
 
 
 # english function to show plural and singular forms of alternatives for nouns

--- a/app/main.py
+++ b/app/main.py
@@ -603,6 +603,22 @@ def check_category_importance(config: Config, subcategory: str):
     )
 
 
+# function to convern word_type to SpaCy part-of-the-speech labels
+def type_transform(word_type):
+    noun = "NOUN"
+    verb = "VERB"
+    adj = "ADJ"
+    adv = "ADV"
+    if word_type == "s":
+        return noun
+    if word_type == "v":
+        return verb
+    if word_type == "a":
+        return adj
+    if word_type == "adv":
+        return adv
+
+
 def is_sub_category_enabled(config: Config, subcategory: str):
     if categories[subcategory]["category"] in config.disabled_categories:
         return False
@@ -1658,6 +1674,44 @@ def rules_based_words_phrase_matcher_en(
                 )
 
     return list_tokens
+
+for (
+            word,
+            alternative_sing,
+            alternative_plur,
+            subcategory,
+        ) in gendered_words_alternatives:
+
+
+
+# english function to handle homonyms
+def homonyms_english(
+    version: float,
+    config: Config,
+    lang,
+    full_text,
+    tokens,
+    homonyms_words
+    ):
+
+    list_tokens = []
+    for token in tokens:
+         for word, word_type, category, subcategory, alternative in homonyms_words:
+                if token.lemma_ == word and token.pos_ == type_transform(word_type):
+                    list_tokens.append(
+                        ResultOut.factory(
+                            version,
+                            config,
+                            lang,
+                            token.text,
+                            full_text,
+                            category,
+                            subcategory,
+                            token.idx,
+                            token.idx + len(token.text),
+                            ast.literal_eval(alternative),
+                    )
+            
 
 
 # english function to show plural and singular forms of alternatives for nouns

--- a/app/main.py
+++ b/app/main.py
@@ -604,18 +604,18 @@ def check_category_importance(config: Config, subcategory: str):
 
 
 # function to convern word_type to SpaCy part-of-the-speech labels
-def type_transform(word_type):
+def type_transform(lemma_type):
     noun = "NOUN"
     verb = "VERB"
     adj = "ADJ"
     adv = "ADV"
-    if word_type == "s":
+    if lemma_type == "s":
         return noun
-    if word_type == "v":
+    if lemma_type == "v":
         return verb
-    if word_type == "a":
+    if lemma_type == "a":
         return adj
-    if word_type == "adv":
+    if lemma_type == "adv":
         return adv
 
 
@@ -774,7 +774,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
 
     list_full += homonyms_english(
-        version, config, lang, text, tokens, rules[lang.locale]["df_homonyms_word"]
+        version, config, lang, text, tokens, rules[lang.locale]["df_homonyms_words"]
     )
 
     if is_sub_category_enabled(config, "openly_discriminating"):

--- a/app/main.py
+++ b/app/main.py
@@ -1687,7 +1687,10 @@ def homonyms_english(
 
     list_tokens = []
     for token in tokens:
+
         for word, word_type, category, subcategory, alternative in homonyms_words:
+            if not is_sub_category_enabled(config, subcategory):
+                continue
             if token.lemma_ == word and token.pos_ == type_transform(word_type):
                 list_tokens.append(
                     ResultOut.factory(

--- a/app/main.py
+++ b/app/main.py
@@ -605,18 +605,14 @@ def check_category_importance(config: Config, subcategory: str):
 
 # function to convern word_type to SpaCy part-of-the-speech labels
 def type_transform(lemma_type):
-    noun = "NOUN"
-    verb = "VERB"
-    adj = "ADJ"
-    adv = "ADV"
     if lemma_type == "s":
-        return noun
+        return "NOUN"
     if lemma_type == "v":
-        return verb
+        return "VERB"
     if lemma_type == "a":
-        return adj
+        return "ADJ"
     if lemma_type == "adv":
-        return adv
+        return "ADV"
 
 
 def is_sub_category_enabled(config: Config, subcategory: str):

--- a/app/rules.py
+++ b/app/rules.py
@@ -49,7 +49,7 @@ rules = {
         "df_ub_sentence": "ub_sentences.csv",
         "df_ub_singular_they": "ub_singular_they.csv",
         # load homonyms
-        "df_homonyms_word": "homonyms_words.csv",
+        "df_homonyms_words": "homonyms_words.csv",
     },
 }
 
@@ -288,13 +288,13 @@ inclusive_words_alternatives_GB = list(
     zip(df_inclusive_GB["Lemma"], df_inclusive_GB["Primary_subcategory"])
 )
 # df homonyms words
-df_homonyms_US = rules["en-US"]["df_homonyms_word"]
-df_homonyms_GB = rules["en-GB"]["df_homonyms_word"]
+df_homonyms_US = rules["en-US"]["df_homonyms_words"]
+df_homonyms_GB = rules["en-GB"]["df_homonyms_words"]
 # homonyms : lemma+word_type+category+subcategory+alternatives
 homonyms_word_US = list(
     zip(
         df_homonyms_US["Lemma"],
-        df_homonyms_US["Word_type"],
+        df_homonyms_US["Word_Type"],
         df_homonyms_US["Category"],
         df_homonyms_US["Primary_subcategory"],
         df_homonyms_US["Alt_split"],

--- a/app/rules.py
+++ b/app/rules.py
@@ -48,6 +48,8 @@ rules = {
         "df_ub_no_plur_word": "ub_no_plur_words.csv",
         "df_ub_sentence": "ub_sentences.csv",
         "df_ub_singular_they": "ub_singular_they.csv",
+        # load homonyms
+        "df_homonyms_word": "homonyms_words.csv",
     },
 }
 
@@ -284,6 +286,28 @@ inclusive_words_alternatives_US = list(
 )
 inclusive_words_alternatives_GB = list(
     zip(df_inclusive_GB["Lemma"], df_inclusive_GB["Primary_subcategory"])
+)
+# df homonyms words
+df_homonyms_US = rules["en-US"]["df_homonyms_word"]
+df_homonyms_GB = rules["en-GB"]["df_homonyms_word"]
+# homonyms : lemma+word_type+category+subcategory+alternatives
+homonyms_word_US = list(
+    zip(
+        df_homonyms_US["Lemma"],
+        df_homonyms_US["Word_type"],
+        df_homonyms_US["Category"],
+        df_homonyms_US["Primary_subcategory"],
+        df_homonyms_US["Alt_split"],
+    )
+)
+homonyms_word_GB = list(
+    zip(
+        df_homonyms_GB["Lemma"],
+        df_homonyms_GB["Word_type"],
+        df_homonyms_GB["Category"],
+        df_homonyms_GB["Primary_subcategory"],
+        df_homonyms_GB["Alt_split"],
+    )
 )
 # df gendered noun
 df_gender_noun_US = rules["en-US"]["df_gendered_noun_word"]

--- a/app/rules.py
+++ b/app/rules.py
@@ -303,7 +303,7 @@ homonyms_word_US = list(
 homonyms_word_GB = list(
     zip(
         df_homonyms_GB["Lemma"],
-        df_homonyms_GB["Word_type"],
+        df_homonyms_GB["Word_Type"],
         df_homonyms_GB["Category"],
         df_homonyms_GB["Primary_subcategory"],
         df_homonyms_GB["Alt_split"],

--- a/tests/test_demo_wordings_english/test_internal_email/output.json
+++ b/tests/test_demo_wordings_english/test_internal_email/output.json
@@ -24,6 +24,73 @@
         {
             "alternatives": [
                 {
+                    "text": "question"
+                },
+                {
+                    "text": "cross-examine"
+                },
+                {
+                    "text": "re-evaluate"
+                },
+                {
+                    "text": "object to"
+                },
+                {
+                    "text": "express the need for"
+                }
+            ],
+            "category": "unconscious_bias",
+            "context": "e are a team where ambition and perseverance count.\nCompetition is our daily life and we love to be challenged.\nWe are number 1 and innovation drives us.\nSincere regards,\nNadia",
+            "end": 121,
+            "explanation": {
+                "icon": "😒",
+                "text": "Deters people with a “we” mindset",
+                "url": "https://www.witty.works/en/categories/biased_language#agentic"
+            },
+            "gravity": 2,
+            "label": "Biased language: Agentic",
+            "start": 111,
+            "subcategory": "agentic",
+            "text": "challenged"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "invest in"
+                },
+                {
+                    "text": "support"
+                },
+                {
+                    "text": "work toward"
+                },
+                {
+                    "text": "take responsibility for"
+                },
+                {
+                    "text": "dedicated"
+                },
+                {
+                    "text": "invested"
+                }
+            ],
+            "category": "unconscious_bias",
+            "context": "e count.\nCompetition is our daily life and we love to be challenged.\nWe are number 1 and innovation drives us.\nSincere regards,\nNadia",
+            "end": 160,
+            "explanation": {
+                "icon": "😒",
+                "text": "Deters people with a “we” mindset",
+                "url": "https://www.witty.works/en/categories/biased_language#agentic"
+            },
+            "gravity": 2,
+            "label": "Biased language: Agentic",
+            "start": 154,
+            "subcategory": "agentic",
+            "text": "drives"
+        },
+        {
+            "alternatives": [
+                {
                     "text": "people"
                 },
                 {

--- a/tests/test_demo_wordings_english/test_job_ad/output.json
+++ b/tests/test_demo_wordings_english/test_job_ad/output.json
@@ -5,6 +5,50 @@
         {
             "alternatives": [
                 {
+                    "text": "test"
+                },
+                {
+                    "text": "burning question"
+                },
+                {
+                    "text": "complex situation"
+                },
+                {
+                    "text": "task"
+                },
+                {
+                    "text": "task requiring thought and skill to solve"
+                },
+                {
+                    "text": "complex questions"
+                },
+                {
+                    "text": "difficult tasks"
+                },
+                {
+                    "text": "burning questions"
+                },
+                {
+                    "text": "tasks"
+                }
+            ],
+            "category": "unconscious_bias",
+            "context": "As an independent project manager, you will be working on\nexceptional challenges and, together\nwith your ambitious colleagues, you will strive for a top performance.",
+            "end": 80,
+            "explanation": {
+                "icon": "😒",
+                "text": "Deters people with a “we” mindset",
+                "url": "https://www.witty.works/en/categories/biased_language#agentic"
+            },
+            "gravity": 2,
+            "label": "Biased language: Agentic",
+            "start": 70,
+            "subcategory": "agentic",
+            "text": "challenges"
+        },
+        {
+            "alternatives": [
+                {
                     "text": "project management"
                 },
                 {

--- a/tests/test_demo_wordings_english/test_website_short_sentences_example2/output.json
+++ b/tests/test_demo_wordings_english/test_website_short_sentences_example2/output.json
@@ -5,6 +5,50 @@
         {
             "alternatives": [
                 {
+                    "text": "test"
+                },
+                {
+                    "text": "burning question"
+                },
+                {
+                    "text": "complex situation"
+                },
+                {
+                    "text": "task"
+                },
+                {
+                    "text": "task requiring thought and skill to solve"
+                },
+                {
+                    "text": "complex questions"
+                },
+                {
+                    "text": "difficult tasks"
+                },
+                {
+                    "text": "burning questions"
+                },
+                {
+                    "text": "tasks"
+                }
+            ],
+            "category": "unconscious_bias",
+            "context": "We've got exceptional challenges ahead!",
+            "end": 32,
+            "explanation": {
+                "icon": "😒",
+                "text": "Deters people with a “we” mindset",
+                "url": "https://www.witty.works/en/categories/biased_language#agentic"
+            },
+            "gravity": 2,
+            "label": "Biased language: Agentic",
+            "start": 22,
+            "subcategory": "agentic",
+            "text": "challenges"
+        },
+        {
+            "alternatives": [
+                {
                     "remove": true
                 }
             ],

--- a/training_data/en-GB/homonyms_words.csv
+++ b/training_data/en-GB/homonyms_words.csv
@@ -1,0 +1,47 @@
+Lemma,Word_Type,Category,Primary_subcategory,Alt_split
+challenge,v,unconscious_bias,agentic,"['question', 'cross-examine', 're-evaluate', 'object to', 'express the need for']"
+challenge,s,unconscious_bias,agentic,"['test', 'burning question', 'complex situation', 'task', 'task requiring thought and skill to solve', 'complex questions', 'difficult tasks', 'burning questions', 'tasks']"
+direct,v,unconscious_bias,agentic,"['guide', 'show', 'point', 'organise', 'encourage', 'assign roles']"
+direct,a,unconscious_bias,agentic,"['straightfoward', 'open', 'candid']"
+drive,v,unconscious_bias,agentic,"['invest in', 'support', 'work toward', 'take responsibility for', 'dedicated', 'invested']"
+drive,s,unconscious_bias,agentic,"['spirit', 'energy', 'motivation', 'appetite', 'growth mindset']"
+elderly,a,unconscious_bias,age_old,['older']
+elderly,s,unconscious_bias,age_old,"['older adult', 'older people']"
+female,s,unconscious_bias,gender_identity,"['person', 'adult', 'woman', 'you', 'they', 'person who self-identifies as female', 'person who presents themselves in a culturally feminine way', 'team', 'crowd']"
+female,a,unconscious_bias,gender_identity,"['--- only if gender identity is relevant', '--- only if self-identifies as female']"
+fight,s,unconscious_bias,agentic,"['campaign', 'movement', 'initiative', 'encounter', 'debate', 'discussion', 'spirit']"
+fight,v,unconscious_bias,agentic,"['stand up to', 'make a stand', 'strive', 'engage with', 'overcome', 'face', 'hold back']"
+force,s,unconscious_bias,agentic,"['aptitude', 'capability', 'capacity', 'competence', 'competency', 'effectiveness', 'impact', 'influence', 'agency', 'intensity']"
+force,v,unconscious_bias,agentic,"['support', 'shape', 'guide', 'bring about', 'win over', 'produce through effort', 'shape the outcome', 'set the course']"
+handicap,a,unconscious_bias,ability,"['accessible (parking, bathroom, spaces, ...)']"
+handicap,s,unconscious_bias,ability,"['disability', 'impairment']"
+lead,s,gendered,leadership,"['guide', 'mentor', 'facilitator', 'supporter', 'person who inspires, encourages and provide suggestions to help their team reach shared goals', 'guides', 'mentors', 'facilitators', 'supporters', 'people who inspire, encourage and provide suggestions to help their team reach shared goals']"
+lead,v,gendered,leadership,"['be responsible for', 'counsel', 'mentor', 'guide', 'coach', 'support and motivate', 'communicate the vision (shared goals, a direction, expectations, ...)']"
+male,s,unconscious_bias,gender_identity,"['person', 'adult', 'individual', 'you', 'they', 'person who self-identifies as male', 'person who presents themselves in a culturally masculine way', 'people', 'team', 'crowd', 'all', 'you all', 'persons', 'everyone']"
+male,a,unconscious_bias,gender_identity,['masculine']
+man,s,unconscious_bias,gender_identity,"['person', 'adult', 'individual', 'you', 'person who self-identifies as male', 'person who presents themselves in a culturally masculine way', 'people', 'team', 'crowd', 'all', 'you all', 'persons', 'everyone']"
+man,v,gendered,hidden_image,"['staff', 'crew', 'occupy', 'work', 'use']"
+manward,adv,gendered,hidden_image,['from a human point of view']
+manward,a,gendered,hidden_image,"['directed toward humankind', 'relating to humanity']"
+master,s,unconscious_bias,racist_source,"['main --- in technology', 'default --- in technology', 'primary --- in technology', 'root --- in technology']"
+master,v,unconscious_bias,agentic,"['learn', 'understand', 'overcome', 'regulate', 'manage', 'guide', 'become competent (in)']"
+must-have,a,style,exaggerating,"['essential', 'helpful', 'valuable', 'mission-critical', 'vital', 'beneficial']"
+must-have,s,style,exaggerating,"['requirement', 'criterion', 'essential', 'quality required to (...)']"
+musthave,a,style,exaggerating,"['essential', 'helpful', 'valuable', 'mission-critical', 'vital', 'beneficial']"
+musthave,s,style,exaggerating,"['requirement', 'criterion', 'essential', 'quality required to (...)']"
+nag,v,gendered,female_stereotype,"['criticise', 'annoy', 'repeatedly comment (on something ...)', 'openly share (their) doubts', ""repeatedly complain (about someone's behaviour, appearance, ...)"", 'annoy with repeated requests/orders']"
+nag,s,gendered,female_stereotype,"['critic', 'they', 'person who repeatedly shares their reservations', 'person continuing to be open about their doubts', ""someone who annoys by repeatedly complaining (about someone's behaviour, appearance, ...)"", 'person who annoys (someone) with repeated questions/requests/orders', 'critics']"
+objective,s,unconscious_bias,agentic,"['intention', 'purpose', 'aspiration', 'goal', 'aim', 'idea', 'intent', 'plan', 'point', 'desire', 'hope', 'wish']"
+objective,a,unconscious_bias,agentic,"['unbiased', 'open-minded', 'evenhanded', 'equitable', 'fair', 'unprejudiced', 'nondiscriminatory', 'nonpartisan', 'based on your experience', 'based on your observations', 'based on facts and data', 'actual', 'real', 'balanced', 'rational', 'reasonable', 'straightforward']"
+pioneer,v,unconscious_bias,agentic,"['guide', 'coach', 'inspire', 'introduce', 'launch', 'chart a new course', 'incorporate a shared vision', 'take (...) in a new direction', 'implement new ideas']"
+pioneer,s,gendered,function,"['inspiring personality', 'visionary', 'person who paved the way', 'person to break new ground', 'someone who charted a new course']"
+psycho,s,unconscious_bias,cognitive_perception,"['person with a chronic mental disorder', 'someone with antisocial, egocentric, or violent social behaviour', 'violent person', 'unemotional person', 'callous person', 'person who lacks empathy', 'person who lacks remorse for their actions']"
+psycho,a,unconscious_bias,cognitive_perception,"['violent', 'unemotional', 'callous', 'lacking empathy', 'unable to feel remorse', 'selfish', 'self-centred', 'toxic', 'manipulative', 'egotistical', 'abusive', 'confusing', 'unpredictable', 'scary']"
+queer,s,unconscious_bias,gender_identity,"['LGBTIQA+', 'queer communities']"
+queer,a,unconscious_bias,gender_identity,"['LGBTIQA+', 'genderqueer', 'genderfluid']"
+sass,s,unconscious_bias,culture,"['spirit', 'cheek', 'backtalk', 'candidness', 'frankness']"
+sass,v,unconscious_bias,culture,['talk back to']
+schizo,s,unconscious_bias,cognitive_perception,['person with schizophrenia']
+schizo,a,unconscious_bias,cognitive_perception,['wildly eccentric']
+wacko,s,openly_discriminating,ableism,['-']
+wacko,a,unconscious_bias,behavior,"['absurd', 'amusingly eccentric', 'irrational', 'bizarre', 'unpredictable']"

--- a/training_data/en-US/homonyms_words.csv
+++ b/training_data/en-US/homonyms_words.csv
@@ -1,0 +1,47 @@
+Lemma,Word_Type,Category,Primary_subcategory,Alt_split
+challenge,v,unconscious_bias,agentic,"['question', 'cross-examine', 're-evaluate', 'object to', 'express the need for']"
+challenge,s,unconscious_bias,agentic,"['test', 'burning question', 'complex situation', 'task', 'task requiring thought and skill to solve', 'complex questions', 'difficult tasks', 'burning questions', 'tasks']"
+direct,v,unconscious_bias,agentic,"['guide', 'show', 'point', 'organize', 'encourage', 'assign roles']"
+direct,a,unconscious_bias,agentic,"['straightfoward', 'open', 'candid']"
+drive,v,unconscious_bias,agentic,"['invest in', 'support', 'work toward', 'take responsibility for', 'dedicated', 'invested']"
+drive,s,unconscious_bias,agentic,"['spirit', 'energy', 'motivation', 'appetite', 'growth mindset']"
+elderly,a,unconscious_bias,age_old,['older']
+elderly,s,unconscious_bias,age_old,"['older adult', 'older people']"
+female,s,unconscious_bias,gender_identity,"['person', 'adult', 'woman', 'you', 'they', 'person who self-identifies as female', 'person who presents themselves in a culturally feminine way', 'team', 'crowd']"
+female,a,unconscious_bias,gender_identity,"['--- only if gender identity is relevant', '--- only if self-identifies as female']"
+fight,s,unconscious_bias,agentic,"['campaign', 'movement', 'initiative', 'encounter', 'debate', 'discussion', 'spirit']"
+fight,v,unconscious_bias,agentic,"['stand up to', 'make a stand', 'strive', 'engage with', 'overcome', 'face', 'hold back']"
+force,s,unconscious_bias,agentic,"['aptitude', 'capability', 'capacity', 'competence', 'competency', 'effectiveness', 'impact', 'influence', 'agency', 'intensity']"
+force,v,unconscious_bias,agentic,"['support', 'shape', 'guide', 'bring about', 'win over', 'produce through effort', 'shape the outcome', 'set the course']"
+handicap,a,unconscious_bias,ability,"['accessible (parking, bathroom, spaces, ...)']"
+handicap,s,unconscious_bias,ability,"['disability', 'impairment']"
+lead,s,gendered,leadership,"['guide', 'mentor', 'facilitator', 'supporter', 'person who inspires, encourages and provide suggestions to help their team reach shared goals', 'guides', 'mentors', 'facilitators', 'supporters', 'people who inspire, encourage and provide suggestions to help their team reach shared goals']"
+lead,v,gendered,leadership,"['be responsible for', 'counsel', 'mentor', 'guide', 'coach', 'support and motivate', 'communicate the vision (shared goals, a direction, expectations, ...)']"
+male,s,unconscious_bias,gender_identity,"['person', 'adult', 'individual', 'you', 'they', 'person who self-identifies as male', 'person who presents themselves in a culturally masculine way', 'people', 'team', 'crowd', 'all', 'you all', 'persons', 'everyone']"
+male,a,unconscious_bias,gender_identity,['masculine']
+man,s,unconscious_bias,gender_identity,"['person', 'adult', 'individual', 'you', 'person who self-identifies as male', 'person who presents themselves in a culturally masculine way', 'people', 'team', 'crowd', 'all', 'you all', 'persons', 'everyone']"
+man,v,gendered,hidden_image,"['staff', 'crew', 'occupy', 'work', 'use']"
+manward,adv,gendered,hidden_image,['from a human point of view']
+manward,a,gendered,hidden_image,"['directed toward humankind', 'relating to humanity']"
+master,s,unconscious_bias,racist_source,"['main --- in technology', 'default --- in technology', 'primary --- in technology', 'root --- in technology']"
+master,v,unconscious_bias,agentic,"['learn', 'understand', 'overcome', 'regulate', 'manage', 'guide', 'become competent (in)']"
+must-have,a,style,exaggerating,"['essential', 'helpful', 'valuable', 'mission-critical', 'vital', 'beneficial']"
+must-have,s,style,exaggerating,"['requirement', 'criterion', 'essential', 'quality required to (...)']"
+musthave,a,style,exaggerating,"['essential', 'helpful', 'valuable', 'mission-critical', 'vital', 'beneficial']"
+musthave,s,style,exaggerating,"['requirement', 'criterion', 'essential', 'quality required to (...)']"
+nag,v,gendered,female_stereotype,"['criticize', 'annoy', 'repeatedly comment (on something ...)', 'openly share (their) doubts', ""repeatedly complain (about someone's behavior, appearance, ...)"", 'annoy with repeated requests/orders']"
+nag,s,gendered,female_stereotype,"['critic', 'they', 'person who repeatedly shares their reservations', 'person continuing to be open about their doubts', ""someone who annoys by repeatedly complaining (about someone's behavior, appearance, ...)"", 'person who annoys (someone) with repeated questions/requests/orders', 'critics']"
+objective,s,unconscious_bias,agentic,"['intention', 'purpose', 'aspiration', 'goal', 'aim', 'idea', 'intent', 'plan', 'point', 'desire', 'hope', 'wish']"
+objective,a,unconscious_bias,agentic,"['unbiased', 'open-minded', 'evenhanded', 'equitable', 'fair', 'unprejudiced', 'nondiscriminatory', 'nonpartisan', 'based on your experience', 'based on your observations', 'based on facts and data', 'actual', 'real', 'balanced', 'rational', 'reasonable', 'straightforward']"
+pioneer,v,unconscious_bias,agentic,"['guide', 'coach', 'inspire', 'introduce', 'launch', 'chart a new course', 'incorporate a shared vision', 'take (...) in a new direction', 'implement new ideas']"
+pioneer,s,gendered,function,"['inspiring personality', 'visionary', 'person who paved the way', 'person to break new ground', 'someone who charted a new course']"
+psycho,s,unconscious_bias,cognitive_perception,"['person with a chronic mental disorder', 'someone with antisocial, egocentric, or violent social behavior', 'violent person', 'unemotional person', 'callous person', 'person who lacks empathy', 'person who lacks remorse for their actions']"
+psycho,a,unconscious_bias,cognitive_perception,"['violent', 'unemotional', 'callous', 'lacking empathy', 'unable to feel remorse', 'selfish', 'self-centered', 'toxic', 'manipulative', 'egotistical', 'abusive', 'confusing', 'unpredictable', 'scary']"
+queer,s,unconscious_bias,gender_identity,"['LGBTIQA+', 'queer communities']"
+queer,a,unconscious_bias,gender_identity,"['LGBTIQA+', 'genderqueer', 'genderfluid']"
+sass,s,unconscious_bias,culture,"['spirit', 'cheek', 'backtalk', 'candidness', 'frankness']"
+sass,v,unconscious_bias,culture,['talk back to']
+schizo,s,unconscious_bias,cognitive_perception,['person with schizophrenia']
+schizo,a,unconscious_bias,cognitive_perception,['wildly eccentric']
+wacko,s,openly_discriminating,ableism,['-']
+wacko,a,unconscious_bias,behavior,"['absurd', 'amusingly eccentric', 'irrational', 'bizarre', 'unpredictable']"


### PR DESCRIPTION
related to [374](https://github.com/witty-works/nlp_api/issues/374)
- function type_transform
To transform word_type from rules to SpaCy part-of-the-speech labels
- function homonyms_english
To show different alternatives depending on the part-of-the-speech (word_type) 

Example1: "He took up the challenge.", word challenge is `noun`, alternatives to show:
        "test",
        "burning question",
        "complex situation",
        "task",
        "task requiring thought and skill to solve",
        "complex questions",
        "difficult tasks",
        "burning questions",
        "tasks"
Example2: "My new theory challenges the traditional ideas.", word challenge is `verb`, alternatives to show: 
        "question",
        "cross-examine",
        "re-evaluate",
        "object to",
        "express the need for"
