### PR TITLE
return organization config if available

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -304,7 +304,7 @@ async def check_v1_1(
 
 # data exchange routes
 @app.post("/store_rules")
-async def store_redis(
+async def store_rules(
     organization_rules: ConfRequest, username: str = Depends(get_current_username)
 ):
     try:
@@ -502,7 +502,13 @@ async def check(
         version, user_request_in.config, organization_rules, lang, text
     )
 
-    return ResultsOut.factory(list_results, lang.lang, limit_reached)
+    organization_config = None
+    if "config" in organization_rules:
+        organization_config = organization_rules["config"]
+
+    return ResultsOut.factory(
+        list_results, lang.lang, limit_reached, organization_config
+    )
 
 
 def get_alternatives(match):

--- a/app/models.py
+++ b/app/models.py
@@ -160,11 +160,11 @@ class Config(BaseModel):
 class OrganizationConfig(BaseModel):
     store_context: Optional[bool]
     primary_language: Optional[LangWithAutoType]
-    preferred_languages: List[str] = []
-    preferred_variants: List[str] = []
+    preferred_languages: Optional[List[str]]
+    preferred_variants: Optional[List[str]]
     german_gender_ending: Optional[GermanGenderEndingType]
-    disabled_categories: List[str] = []
     gendered_roles_format: Optional[GenderedRolesFormatType]
+    disabled_categories: Optional[List[str]]
     singular_they: Optional[SingularTheyType]
     show_inspiration_alternatives: Optional[bool]
     maximum_importance: Optional[int]
@@ -638,17 +638,35 @@ class Result(BaseModel):
         object.__setattr__(self, "detail", detail)
 
 
+class ResultConf(BaseModel):
+    forced: OrganizationConfig
+    suggestion: OrganizationConfig
+
+
 class ResultsOut(BaseModel):
     results: Union[List[ResultOut], List[ResultOutOld]]
     language: str
     limit_reached: bool
+    organization_config: Union[ResultConf, bool]
 
-    def factory(results, language, limit_reached=False):
-        return ResultsOut(results, language, limit_reached)
+    def factory(results, language, limit_reached=False, organization_config=None):
+        if organization_config != None:
+            organization_config["forced"] = OrganizationConfig.parse_obj(
+                organization_config["forced"]
+            )
+            organization_config["suggestion"] = OrganizationConfig.parse_obj(
+                organization_config["suggestion"]
+            )
+            organization_config = ResultConf.parse_obj(organization_config)
+        else:
+            organization_config = False
+
+        return ResultsOut(results, language, limit_reached, organization_config)
 
     factory = staticmethod(factory)
 
-    def __init__(self, results, language, limit_reached):
+    def __init__(self, results, language, limit_reached, organization_config):
         object.__setattr__(self, "results", results)
         object.__setattr__(self, "language", language)
         object.__setattr__(self, "limit_reached", limit_reached)
+        object.__setattr__(self, "organization_config", organization_config)

--- a/tests/test_1_0/test_api/output.json
+++ b/tests/test_1_0/test_api/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -478,7 +478,7 @@ def test_store_and_get_rules():
         response_content["config"]["suggestion"]["german_gender_ending"]
         == request_data["suggestion"]["german_gender_ending"]
     )
-    assert response_content["config"]["suggestion"]["preferred_variants"] == []
+    assert response_content["config"]["suggestion"]["preferred_variants"] == None
     assert response_content["false_positives"] == request_data["false_positives"]
     assert response_content["term_replacements"] == request_data["term_replacements"]
 

--- a/tests/test_demo_wordings_english/test_external_communication/output.json
+++ b/tests/test_demo_wordings_english/test_external_communication/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_english/test_internal_communication_example1/output.json
+++ b/tests/test_demo_wordings_english/test_internal_communication_example1/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [],

--- a/tests/test_demo_wordings_english/test_internal_communication_example2/output.json
+++ b/tests/test_demo_wordings_english/test_internal_communication_example2/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_english/test_internal_email/output.json
+++ b/tests/test_demo_wordings_english/test_internal_email/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_english/test_job_ad/output.json
+++ b/tests/test_demo_wordings_english/test_job_ad/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_english/test_website_short_sentences_example1/output.json
+++ b/tests/test_demo_wordings_english/test_website_short_sentences_example1/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [],

--- a/tests/test_demo_wordings_english/test_website_short_sentences_example2/output.json
+++ b/tests/test_demo_wordings_english/test_website_short_sentences_example2/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_english/test_website_short_sentences_example3/output.json
+++ b/tests/test_demo_wordings_english/test_website_short_sentences_example3/output.json
@@ -1,5 +1,6 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_demo_wordings_german/test_internal_email/output.json
+++ b/tests/test_demo_wordings_german/test_internal_email/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_german/test_job_ad/output.json
+++ b/tests/test_demo_wordings_german/test_job_ad/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_german/test_website_short_sentences_example1/output.json
+++ b/tests/test_demo_wordings_german/test_website_short_sentences_example1/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_demo_wordings_german/test_website_short_sentences_example2/output.json
+++ b/tests/test_demo_wordings_german/test_website_short_sentences_example2/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_demo_wordings_german/test_website_short_sentences_example3/output.json
+++ b/tests/test_demo_wordings_german/test_website_short_sentences_example3/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_false_positive/test_api_corporate_false_positives/output.json
+++ b/tests/test_false_positive/test_api_corporate_false_positives/output.json
@@ -1,5 +1,20 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": {
+        "forced": {
+            "gendered_roles_format": "binary_gender",
+            "german_gender_ending": "In",
+            "preferred_languages": [
+                "en"
+            ],
+            "preferred_variants": [
+                "en-GB"
+            ],
+            "primary_language": "en-GB",
+            "store_context": false
+        },
+        "suggestion": {}
+    },
     "results": []
 }

--- a/tests/test_false_positive/test_api_false_positive/output.json
+++ b/tests/test_false_positive/test_api_false_positive/output.json
@@ -1,5 +1,20 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": {
+        "forced": {
+            "gendered_roles_format": "binary_gender",
+            "german_gender_ending": "In",
+            "preferred_languages": [
+                "en"
+            ],
+            "preferred_variants": [
+                "en-GB"
+            ],
+            "primary_language": "en-GB",
+            "store_context": false
+        },
+        "suggestion": {}
+    },
     "results": []
 }

--- a/tests/test_false_positive/test_gender_false_positive/output.json
+++ b/tests/test_false_positive/test_gender_false_positive/output.json
@@ -1,5 +1,20 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": {
+        "forced": {
+            "gendered_roles_format": "binary_gender",
+            "german_gender_ending": "In",
+            "preferred_languages": [
+                "en"
+            ],
+            "preferred_variants": [
+                "en-GB"
+            ],
+            "primary_language": "en-GB",
+            "store_context": false
+        },
+        "suggestion": {}
+    },
     "results": []
 }

--- a/tests/test_gender_ending/test_api_gender_ending/output.json
+++ b/tests/test_gender_ending/test_api_gender_ending/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_gender_ending/test_api_gender_ending_custom/output.json
+++ b/tests/test_gender_ending/test_api_gender_ending_custom/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_gender_ending/test_api_gender_ending_seine_frau/output.json
+++ b/tests/test_gender_ending/test_api_gender_ending_seine_frau/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_gender_ending/test_api_gender_endings/output.json
+++ b/tests/test_gender_ending/test_api_gender_endings/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_gender_ending/test_api_gender_endings_capital_i/output.json
+++ b/tests/test_gender_ending/test_api_gender_endings_capital_i/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_gender_ending/test_api_gender_endings_do_not_trigger_spellchecker/output.json
+++ b/tests/test_gender_ending/test_api_gender_endings_do_not_trigger_spellchecker/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_gender_ending/test_api_gender_sinti_romnja-capitalize/output.json
+++ b/tests/test_gender_ending/test_api_gender_sinti_romnja-capitalize/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_gender_ending/test_api_gender_sinti_romnja-slash-dash/output.json
+++ b/tests/test_gender_ending/test_api_gender_sinti_romnja-slash-dash/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_gender_ending/test_api_gender_sinti_romnja/output.json
+++ b/tests/test_gender_ending/test_api_gender_sinti_romnja/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api/output.json
+++ b/tests/test_general_cases/test_api/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_abbreviations/output.json
+++ b/tests/test_general_cases/test_api_abbreviations/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_capitalize_alternatives/output.json
+++ b/tests/test_general_cases/test_api_capitalize_alternatives/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_context/output.json
+++ b/tests/test_general_cases/test_api_context/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_disabled_categories/output.json
+++ b/tests/test_general_cases/test_api_disabled_categories/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_english-behavior-GB/output.json
+++ b/tests/test_general_cases/test_api_english-behavior-GB/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_english/output.json
+++ b/tests/test_general_cases/test_api_english/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_english_singular_they/output.json
+++ b/tests/test_general_cases/test_api_english_singular_they/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_gendered_subcategories/output.json
+++ b/tests/test_general_cases/test_api_gendered_subcategories/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_gravity/output.json
+++ b/tests/test_general_cases/test_api_gravity/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_show_inspiration/output.json
+++ b/tests/test_general_cases/test_api_show_inspiration/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_general_cases/test_api_text_max_length/output.json
+++ b/tests/test_general_cases/test_api_text_max_length/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": true,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_highlight_position/test_line_break_counting/output.json
+++ b/tests/test_highlight_position/test_line_break_counting/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_language_detection/test_language_detection_explicit_lang/output.json
+++ b/tests/test_language_detection/test_language_detection_explicit_lang/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_language_detection/test_language_detection_explicit_locale/output.json
+++ b/tests/test_language_detection/test_language_detection_explicit_locale/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_language_detection/test_language_detection_german/output.json
+++ b/tests/test_language_detection/test_language_detection_german/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_language_detection/test_language_detection_lang_prefs_as_list/output.json
+++ b/tests/test_language_detection/test_language_detection_lang_prefs_as_list/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_language_detection/test_language_detection_lang_prefs_as_string/output.json
+++ b/tests/test_language_detection/test_language_detection_lang_prefs_as_string/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_language_detection/test_language_detection_no_lang_prefs/output.json
+++ b/tests/test_language_detection/test_language_detection_no_lang_prefs/output.json
@@ -1,5 +1,6 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_orthography/test_api_orthography_disabled_category/output.json
+++ b/tests/test_orthography/test_api_orthography_disabled_category/output.json
@@ -1,5 +1,6 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_orthography/test_api_orthography_english/output.json
+++ b/tests/test_orthography/test_api_orthography_english/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_orthography/test_api_orthography_german/output.json
+++ b/tests/test_orthography/test_api_orthography_german/output.json
@@ -1,6 +1,7 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_orthography/test_api_orthography_ignore_at_and_hash/output.json
+++ b/tests/test_orthography/test_api_orthography_ignore_at_and_hash/output.json
@@ -1,5 +1,6 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": []
 }

--- a/tests/test_sentry_examples/test_english_morph_token/output.json
+++ b/tests/test_sentry_examples/test_english_morph_token/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_spacy_model/text_with_space/output.json
+++ b/tests/test_spacy_model/text_with_space/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_spacy_model/text_without_space/output.json
+++ b/tests/test_spacy_model/text_without_space/output.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "limit_reached": false,
+    "organization_config": false,
     "results": [
         {
             "alternatives": [

--- a/tests/test_term_replacement/test_api_corporate_term_replacements/output.json
+++ b/tests/test_term_replacement/test_api_corporate_term_replacements/output.json
@@ -1,6 +1,21 @@
 {
     "language": "de",
     "limit_reached": false,
+    "organization_config": {
+        "forced": {
+            "gendered_roles_format": "binary_gender",
+            "german_gender_ending": "In",
+            "preferred_languages": [
+                "en"
+            ],
+            "preferred_variants": [
+                "en-GB"
+            ],
+            "primary_language": "en-GB",
+            "store_context": false
+        },
+        "suggestion": {}
+    },
     "results": [
         {
             "alternatives": [],


### PR DESCRIPTION
fixes https://github.com/witty-works/nlp_api/issues/441

the core idea here is that if a user makes any request, we return the organization config, so that the browser can update the settings in the browser.