### PR TITLE
support a variable number of german gender endings

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -417,7 +417,9 @@ class ResultOut(BaseModel):
 
         preceeding_text = full_text[max(0, start - 5) : start]
         if (
-            re.search(r"(" + punctuation + r"\s*|\s{5})$", preceeding_text, re.MULTILINE)
+            re.search(
+                r"(" + punctuation + r"\s*|\s{5})$", preceeding_text, re.MULTILINE
+            )
             != None
         ):
             is_upper = True
@@ -568,30 +570,31 @@ class ResultOut(BaseModel):
     ):
         alternative_variations = []
 
-        if alternative.count("/") == 2 and " und " in alternative:
-            alternative_list = alternative.split(" und ")
-            alternative_list[0] = ResultOut.getGenderedRoles(
-                gendered_roles_format, german_gender_ending, alternative_list[0]
-            )
-            alternative_list[1] = ResultOut.getGenderedRoles(
-                gendered_roles_format, german_gender_ending, alternative_list[1]
-            )
-            alternative_variations.append(
-                alternative_list[0][0] + " und " + alternative_list[1][0]
-            )
-            if len(alternative_list[0]) == 2:
-                if len(alternative_list[1]) == 2:
-                    alternative_variations.append(
-                        alternative_list[0][1] + " und " + alternative_list[1][1]
-                    )
-                else:
-                    alternative_variations.append(alternative_list[0][1])
-            elif len(alternative_list[1]) == 2:
-                alternative_variations.append(alternative_list[1][1])
-        else:
-            alternative_variations += ResultOut.getGenderedRoles(
-                gendered_roles_format, german_gender_ending, alternative
-            )
+        alternative = alternative.replace("~ und ~", "~~und~~")
+        words = alternative.split()
+        variations_count = 1
+        for i, word in enumerate(words):
+            if "~" in word:
+                word = word.replace("~~und~~", "~ und ~")
+                words[i] = ResultOut.getGenderedRoles(
+                    gendered_roles_format, german_gender_ending, word
+                )
+                variations_count = max(variations_count, len(words[i]))
+
+        for i in range(0, variations_count):
+            alternative_variations.append("")
+
+        for i, word in enumerate(words):
+            if isinstance(word, list) and len(word) < variations_count:
+                word = word * variations_count
+
+            if not isinstance(word, list) or len(word) < variations_count:
+                word = [word] * variations_count
+
+            for v, variation in enumerate(word):
+                alternative_variations[v] = alternative_variations[v] + variation
+                if i < len(words) - 1:
+                    alternative_variations[v] = alternative_variations[v] + " "
 
         return alternative_variations
 
@@ -606,14 +609,14 @@ class ResultOut(BaseModel):
     def getGenderedRolesFormatInclusive(german_gender_ending, alternative):
         variants = alternative.split("~")
         beginning = str(variants[0])
-        if str(variants[1]) == "e":
+        if str(variants[1]) == "e" and len(variants) == 4 and variants[3][-1] == "r":
             beginning += "e"
             ending = "r"
         else:
             ending = str(variants[1])
 
         if german_gender_ending == "In":
-            if alternative.count("~") > 1:
+            if alternative.count("~") > 1 or variants[0][0].isupper():
                 ending = ending[0:1].capitalize() + ending[1:]
                 separator = ""
             else:

--- a/tests/test_gender_ending/test_api_gender_ending_seine_frau/output.json
+++ b/tests/test_gender_ending/test_api_gender_ending_seine_frau/output.json
@@ -5,10 +5,10 @@
         {
             "alternatives": [
                 {
-                    "text": "seinE Partnerin"
+                    "text": "sein/e PartnerIn"
                 },
                 {
-                    "text": "seine Partnerin"
+                    "text": "sein/e Partner/in"
                 }
             ],
             "category": "unconscious_bias",

--- a/tests/test_gender_ending/test_api_gender_sinti_romnja-capitalize/output.json
+++ b/tests/test_gender_ending/test_api_gender_sinti_romnja-capitalize/output.json
@@ -75,7 +75,13 @@
         {
             "alternatives": [
                 {
+                    "text": "RomNi"
+                },
+                {
                     "text": "Rom/ni"
+                },
+                {
+                    "text": "SintIza"
                 },
                 {
                     "text": "Sint/iza"


### PR DESCRIPTION
this makes it possible to support `Profil des~der idealtypischen Kund~in~/~Kunde`

which would then return 

```
[
  "Profil des/der idealtypischen Kund/in",
  "Profil des*der idealtypischen Kund*in",
  "Profil des:der idealtypischen Kund:in",
  "Profil des/der idealtypischen KundIn",
  "Profil des/der idealtypischen Kund/-in",
  "Profil des/der idealtypischen Kundin/Kunde",
  "Profil des_der idealtypischen Kund_in"
]
```