### PR TITLE
hotfix to support alternate german gender ending syntax

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -71,7 +71,12 @@ class GermanGenderEndingType(str, Enum):
     STAR = "*in"
     COLON = ":in"
     CAPITAL_LETTER = "In"
-
+    STR_SLASH = "slash_in"
+    STR_SLASH_DASH = "slash_dash_in"
+    STR_UNDERSCORE = "underscore_in"
+    STR_STAR = "asterisk_in"
+    STR_COLON = "colon_in"
+    STR_CAPITAL_LETTER = "uppercase_in"
 
 class SingularTheyType(str, Enum):
     HE_OR_SHE = "he_or_she"
@@ -119,6 +124,18 @@ class Config(BaseModel):
     @validator("german_gender_ending")
     def valid_german_gender_ending(cls, v: str):
         if v not in Config._gendereddenom_ending:
+            mapping = {
+                GermanGenderEndingType.STR_SLASH: GermanGenderEndingType.SLASH,
+                GermanGenderEndingType.STR_SLASH_DASH: GermanGenderEndingType.SLASH_DASH,
+                GermanGenderEndingType.STR_UNDERSCORE: GermanGenderEndingType.UNDERSCORE,
+                GermanGenderEndingType.STR_STAR: GermanGenderEndingType.STAR,
+                GermanGenderEndingType.STR_COLON: GermanGenderEndingType.COLON,
+                GermanGenderEndingType.STR_CAPITAL_LETTER: GermanGenderEndingType.CAPITAL_LETTER,
+            }
+
+            if v in mapping:
+                return mapping[v]
+
             raise ValueError("Not supported german_gender_ending: " + v)
         return v
 

--- a/tests/test_gender_ending/test_api_gender_ending_alternate_syntax/input.json
+++ b/tests/test_gender_ending/test_api_gender_ending_alternate_syntax/input.json
@@ -1,0 +1,4 @@
+{
+    "text": "Hallo Kunde.",
+    "config": {"store_context": false, "german_gender_ending": "asterisk_in"}
+}

--- a/tests/test_gender_ending/test_api_gender_ending_alternate_syntax/output.json
+++ b/tests/test_gender_ending/test_api_gender_ending_alternate_syntax/output.json
@@ -1,0 +1,47 @@
+{
+    "language": "de",
+    "limit_reached": false,
+    "results": [
+        {
+            "alternatives": [
+                {
+                    "text": "Kund*in"
+                },
+                {
+                    "text": "Kundin/Kunde"
+                },
+                {
+                    "text": "Kundschaft"
+                },
+                {
+                    "text": "Klientel"
+                },
+                {
+                    "text": "Auftraggebende"
+                },
+                {
+                    "text": "Bestellende"
+                },
+                {
+                    "text": "beziehende Person"
+                },
+                {
+                    "text": "beauftragende Firma"
+                }
+            ],
+            "category": "gendered",
+            "context": "Hallo Kunde.",
+            "end": 11,
+            "explanation": {
+                "icon": "😟",
+                "text": "“Mitmeinen” mit männlichen Generikum funktioniert nicht",
+                "url": "https://www.witty.works/de/kategorien/geschlechtsspezifisch#titel"
+            },
+            "gravity": 2,
+            "label": "Geschlechtsspezifisch: Titel",
+            "start": 6,
+            "subcategory": "titles",
+            "text": "Kunde"
+        }
+    ]
+}


### PR DESCRIPTION
the browser extension is sending `colon_in` instead of `:in`
so I am now allowing this representation but I map it to the proper syntax.