### PR TITLE
only filter the number of a number is contained within a string

### DIFF
--- a/app/privacy_filter.py
+++ b/app/privacy_filter.py
@@ -56,7 +56,7 @@ class PrivacyFilter:
         )
 
     def remove_numbers(self, text):
-        return re.sub(r"\w*\d+\w*", "<NUMBER>", text).strip()
+        return re.sub(r"\d+", "<NUMBER>", text)
 
     def remove_email(self, text):
         return re.sub(
@@ -74,7 +74,7 @@ class PrivacyFilter:
         text = self.remove_email(text)
         text = self.remove_url(text)
         text = self.remove_numbers(text)
-        return text
+        return text.strip()
 
     def clean(self, text):
         return self.filter_regular_expressions(text)

--- a/tests/test_general_cases/test_api_privacy/input.json
+++ b/tests/test_general_cases/test_api_privacy/input.json
@@ -1,5 +1,5 @@
 {
-    "text": "Name is Jones, an ambitious person. Phone number is 212-555-5555 http://127.0.0.1:8000/ jones@example.org",
+    "text": "Name is Jones, an ambitious person. Phone number is 212-555-5555 http://127.0.0.1:8000/ jones@example.org my username is jones21.",
     "config": {
         "store_context": false
     }

--- a/tests/test_general_cases/test_api_privacy/output.json
+++ b/tests/test_general_cases/test_api_privacy/output.json
@@ -12,7 +12,7 @@
                 }
             ],
             "category": "unconscious_bias",
-            "context": "Name is Jones, an ambitious person. Phone number is <NUMBER>-<NUMBER>-<NUMBER> <URL> <EMAIL>",
+            "context": "Name is Jones, an ambitious person. Phone number is <NUMBER>-<NUMBER>-<NUMBER> <URL> <EMAIL> my username is jones<NUMBER>",
             "end": 27,
             "explanation": {
                 "context": "don't use for people",


### PR DESCRIPTION
I stumbled over this as I was creating a test for a hashtag containing a number and it replaced the entire hashtag and not just the number, which was the intention of the privacy filter.