### PR TITLE
removed support for the old 1.1 format and endpoints for rules stored in redis

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -756,6 +756,32 @@ async def fetch_organization_rules_for_request(
     return rules
 
 
+def fetch_email_from_claims(claims):
+    try:  # pragma: no cover
+        if claims["aud"] != settings.aadb2c_client_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="access token does not match client id",
+            )
+
+        if "email" in claims:
+            return claims["email"]
+
+        if "emails" in claims and len(claims["emails"]) > 0:
+            return claims["emails"][0]
+
+    except KeyError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="access token does not map to email",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="no email found in claim",
+    )
+
+
 def fetch_user(request: Request):
     if "authorization" in request.headers and request.headers[
         "authorization"
@@ -768,28 +794,7 @@ def fetch_user(request: Request):
                 status_code=status.HTTP_403_FORBIDDEN, detail="access token invalid"
             )
 
-        try:  # pragma: no cover
-            if claims["aud"] != settings.aadb2c_client_id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="access token does not match client id",
-                )
-
-            if "email" in claims:
-                return claims["email"]
-
-            if "emails" in claims and len(claims["emails"]) > 0:
-                return claims["emails"][0]
-
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="no email found in claim",
-            )
-        except KeyError:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="access token does not map to email",
-            )
+        return fetch_email_from_claims(claims)
 
     if settings.testing:
         if "x-auth" in request.headers:
@@ -1974,15 +1979,18 @@ def sentences_matcher(
     full_text,
     tokens,
     sentences_data,
-    sentences_list,
+    df_sentence,
     category,
     fallback_subcategory=None,
 ):
+    if not isinstance(df_sentence, list):
+        df_sentence = list(df_sentence["Lemma"])
+
     list_tokens = []
     alternative = None
     subcategory = fallback_subcategory
 
-    matches = fetch_matches(tokens, sentences_list)
+    matches = fetch_matches(tokens, df_sentence)
     for match_id, start, end in matches:
         span = tokens[start:end]
 
@@ -2001,28 +2009,30 @@ def sentences_matcher(
                     alternative,
                 )
             )
-        else:
-            for sentence, *data in sentences_data:
-                if span.text.lower() == sentence.lower():
-                    if len(data) >= 1:
-                        alternative = data[0]
-                    if len(data) >= 2:
-                        subcategory = data[1]
 
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            span.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            span.start_char,
-                            span.end_char,
-                            alternative,
-                        )
+            continue
+
+        for sentence, *data in sentences_data:
+            if span.text.lower() == sentence.lower():
+                if len(data) >= 1:
+                    alternative = data[0]
+                if len(data) >= 2:
+                    subcategory = data[1]
+
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        span.text,
+                        full_text,
+                        category,
+                        subcategory,
+                        span.start_char,
+                        span.end_char,
+                        alternative,
                     )
+                )
 
     return list_tokens
 
@@ -2109,7 +2119,7 @@ def ub_words_phrase_matcher_de(
         full_text,
         tokens,
         sentences_data,
-        list(df_sentence["Lemma"]),
+        df_sentence,
         category,
     )
 
@@ -2281,11 +2291,7 @@ def word_noun(
             if is_number_list_empty(token_morph_number, token, full_text):
                 continue
 
-            if lang.lang == "de":
-                alternative = plural_or_singular_alternatives_de(
-                    token_morph_number, alternative_sing, alternative_plur
-                )
-            elif lang.lang == "en":
+            if lang.lang == "en":
                 alternative, subcategory = plural_or_singular_en(
                     token,
                     token_morph_number,
@@ -2294,22 +2300,25 @@ def word_noun(
                     subcategory,
                     data[0],
                 )
-
-            if alternative != None:
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        token.idx + len(token.text),
-                        alternative,
-                    )
+            else:
+                alternative = plural_or_singular_alternatives_de(
+                    token_morph_number, alternative_sing, alternative_plur
                 )
+
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    token.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    token.idx,
+                    token.idx + len(token.text),
+                    alternative,
+                )
+            )
 
     return list_tokens
 
@@ -2337,18 +2346,17 @@ def rules_based_words_phrase_matcher(
             if not is_word_match(token, tokens, lang, word, word_type, matches_false):
                 continue
 
+            if len(data) > 1:
+                subcategory = data[1]
+
             if lang.lang == "en":
                 if len(data) > 1:
                     alternative = ing_ify_alternatives(token, data[0])
                     alternative = alternatives_declension(token, lang, alternative)
-                    subcategory = data[1]
                 else:
                     subcategory = data[0]
-            elif lang.lang == "de":
-                if len(data) >= 1:
-                    alternative = alternatives_declension(token, lang, data[0])
-                if len(data) >= 2:
-                    subcategory = data[1]
+            elif len(data) > 0:
+                alternative = alternatives_declension(token, lang, data[0])
 
             list_tokens.append(
                 ResultOut.factory(
@@ -2365,18 +2373,17 @@ def rules_based_words_phrase_matcher(
                 )
             )
 
-    if isinstance(df_sentence, pd.DataFrame):
-        list_tokens += sentences_matcher(
-            version,
-            config,
-            lang,
-            full_text,
-            tokens,
-            sentences_data,
-            list(df_sentence["Lemma"]),
-            category,
-            fallback_subcategory,
-        )
+    list_tokens += sentences_matcher(
+        version,
+        config,
+        lang,
+        full_text,
+        tokens,
+        sentences_data,
+        df_sentence,
+        category,
+        fallback_subcategory,
+    )
 
     return list_tokens
 

--- a/app/main.py
+++ b/app/main.py
@@ -1087,6 +1087,93 @@ def fetch_tokens(lang: Language, text: str):
     return model[lang.lang](text.rstrip().replace("\n", " "))
 
 
+# matcher to false positives
+def is_false_positive_match(list_false_positive, tokens, token):
+    if list_false_positive == None:
+        return False
+
+    for match_id, start, end in list_false_positive:
+        span_false = tokens[start:end]
+        if token.idx in range(span_false.start_char, span_false.end_char):
+            return True
+
+    return False
+
+
+# create false positives patterns based on false positives column
+def false_pattern_match(tokens):
+    # print ("Start:", tokens, [token.pos_ for token in tokens])
+    # list_false_positives = []
+
+    matcher = Matcher(model["en"].vocab)
+
+    # Define a list with nested dictionaries that contains the pattern to be matched
+    # pronoun_verb = [{'POS': 'PRON'}, {'POS': 'VERB'}]
+
+    # patterns for false positives
+
+    # master of + noun
+    pattern_master = [
+        [
+            {"LOWER": "master"},
+            {"LEMMA": "of"},
+            {"POS": {"IN": ["PRON", "NOUN", "PROPN"]}},
+        ],
+        [
+            {"LOWER": "masters"},
+            {"LEMMA": "of"},
+            {"POS": {"IN": ["PRON", "NOUN", "PROPN"]}},
+        ],
+    ]
+    matcher.add("FalsePositivesList", pattern_master)
+
+    # lead+someone(optional)+prepostion(on, down, up, to, away, back, along)
+    pattern_lead_prepos = [
+        [
+            {
+                "LEMMA": "lead",
+                "POS": "VERB",
+            },
+            {"POS": {"IN": ["PRON", "NOUN", "PROPN"]}, "OP": "?"},
+            {
+                "LEMMA": {
+                    "IN": [
+                        "on",
+                        "down",
+                        "up",
+                        "to",
+                        "away",
+                        "back",
+                        "along",
+                        "with",
+                        "off",
+                    ]
+                }
+            },
+        ]
+    ]
+    matcher.add("FalsePositivesList", pattern_lead_prepos)
+
+    # lead a (charmed, busy, quiet, normal, ...) life','lead your (my, his, her, their, our, ...) life'
+    pattern_lead_life = [
+        [
+            {"LEMMA": "lead", "POS": "VERB"},
+            {"POS": "DET", "OP": "?"},
+            {"POS": {"IN": ["ADJ", "PRON"]}, "OP": "?"},
+            {"LOWER": "life"},
+        ]
+    ]
+    matcher.add("FalsePositivesList", pattern_lead_life)
+
+    # need to
+    pattern_need_to = [
+        [{"LEMMA": "need", "POS": "VERB"}, {"LEMMA": {"IN": ["to", "for"]}}]
+    ]
+    matcher.add("FalsePositivesList", pattern_need_to)
+
+    return matcher(tokens)
+
+
 def fetch_false_positive_matcher(tokens):
     # create false positives list
     phrase_matches_false = fetch_matches(tokens, list_false_column)
@@ -1640,6 +1727,17 @@ def add_declension(lang, text, ending):
     return text + ending
 
 
+def is_conjunction(full_text, start=0):
+    if full_text in ["und", "oder", "and", "or"]:
+        return True
+
+    preceeding_text = full_text[max(0, start - 5) : start]
+    return (
+        re.search(r"^ *$", preceeding_text) != None
+        or re.search(r"[.!?:,]\s*$", preceeding_text, re.MULTILINE) != None
+    )
+
+
 def alternative_declension(text, token_type, ending, lang, alternative):
     if ResultOut.isInspirationAlternative(text, alternative):
         return alternative
@@ -1717,49 +1815,6 @@ def alternatives_declension(token, lang, alternatives):
     return alternatives
 
 
-"""Function to catch ending in German Denom"""
-
-
-def gendered_denom_end(
-    version: float,
-    config: Config,
-    lang,
-    full_text,
-    category,
-    subcategory,
-    endings,
-    german_gender_ending=None,
-):
-    list_ending = []
-
-    if not german_gender_ending:
-        alternative = None
-
-    for item, regex in endings.items():
-        matches = re.finditer(r"\s(\S+)(" + regex + ")", full_text)
-        for span in matches:
-            if type(span) == re.Match:
-                if german_gender_ending:
-                    alternative = [span.group(1) + german_gender_ending]
-
-                list_ending.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.group(1) + span.group(2),
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start() + 1,  # remove extra \S character
-                        span.end(),
-                        alternative,
-                    )
-                )
-
-    return list_ending
-
-
 def plural_or_singular_en(
     token,
     token_morph_number,
@@ -1789,6 +1844,127 @@ def plural_or_singular_alternatives_de(
         return alternative_plur
 
     return None
+
+
+def ignore_binary_inclusive_gendered_denom_analysis_de(
+    lang,
+    tokens,
+    false_positives,
+):
+    matches = fetch_matches(tokens, false_positives)
+    if matches.__len__() > 0:
+        old_start = 0
+        rest_text = []
+
+        for match_id, start, end in matches:
+            part = tokens[old_start:start]
+            rest_text.append(part.text)
+            old_start = end
+
+        docs = list(model[lang.lang].pipe(rest_text))
+        tokens = Doc.from_docs(docs)
+
+    return tokens
+
+
+def match_binary_inclusive_gendered_denom_analysis_de(
+    config: Config, false_positives, full_text, token, category, subcategory
+):
+    text = token.text
+    start = token.idx
+    if not ResultOut.genderedRolesFormatBinary(config.gendered_roles_format):
+        for false_positive in false_positives:
+            if not false_positive.endswith(text):
+                continue
+
+            new_start = start - len(false_positive.removesuffix(text))
+            if false_positive == full_text[new_start : new_start + len(false_positive)]:
+                start = new_start
+                text = false_positive
+
+                subcategory = "gendered_denominations_ending"
+                category = categories[subcategory]["category"]
+                break
+
+    return text, start, category, subcategory
+
+
+def find_article(tokens, i):
+    matches = 0
+    article_text = tokens[i - 1].text.lower()
+    gender = get_gender_of_word(tokens[i].text.lower())
+    if gender["definite_article"] == None:
+        return None, None, None, None, None
+
+    for masculine, feminine, neuter, plural, alternative in articles:
+        if (
+            (gender["definite_article"] == "der" and article_text == masculine)
+            or (gender["definite_article"] == "die" and article_text == feminine)
+            or (gender["definite_article"] == "das" and article_text == neuter)
+        ):
+            match_masculine = masculine
+            match_feminine = feminine
+            match_neuter = neuter
+            match_plural = plural
+            match_alternative = alternative
+            matches += 1
+            if matches > 1:
+                break
+
+    if matches == 1:
+        return (
+            match_masculine,
+            match_feminine,
+            match_neuter,
+            match_plural,
+            match_alternative,
+        )
+
+    return None, None, None, None, None
+
+
+def fetch_alternatives_with_article(tokens, i, alternatives):
+    alternatives_with_article = []
+    (
+        masculine,
+        feminine,
+        neuter,
+        plural,
+        alternative_for_article,
+    ) = find_article(tokens, i)
+
+    if alternative_for_article == None:
+        return None
+
+    # also detect if its a person or an institution
+    # in the later case do not offer the Gender-star options
+    # and use subcategory "misgendering_institutions"
+    for alternative in alternatives:
+        if "~" in alternative:
+            article_alternative = alternative_for_article
+        else:
+            if "---" in alternative:
+                (
+                    alternative,
+                    alternative_context,
+                ) = alternative.split("---")
+                alternative = alternative.strip()
+
+            words = alternative.split()
+            gender = get_gender_of_word(words[-1])
+
+            if gender["definite_article"] == "der":
+                article_alternative = masculine
+            elif gender["definite_article"] == "das":
+                article_alternative = neuter
+            elif gender["definite_article"] == "die" or alternative.endswith("in"):
+                article_alternative = feminine
+            else:
+                article_alternative = tokens[i - 1].text
+
+        alternatives_with_article.append(article_alternative + " " + alternative)
+
+    return alternatives_with_article
 
 
 def sentences_matcher(
@@ -1851,8 +2027,44 @@ def sentences_matcher(
     return list_tokens
 
 
-"""Function to handle dependecies of the adjectives."""
-# this function agentic language & related false positives
+def gendered_denom_end(
+    version: float,
+    config: Config,
+    lang,
+    full_text,
+    category,
+    subcategory,
+    endings,
+    german_gender_ending=None,
+):
+    list_ending = []
+
+    if not german_gender_ending:
+        alternative = None
+
+    for item, regex in endings.items():
+        matches = re.finditer(r"\s(\S+)(" + regex + ")", full_text)
+        for span in matches:
+            if type(span) == re.Match:
+                if german_gender_ending:
+                    alternative = [span.group(1) + german_gender_ending]
+
+                list_ending.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        span.group(1) + span.group(2),
+                        full_text,
+                        category,
+                        subcategory,
+                        span.start() + 1,  # remove extra \S character
+                        span.end(),
+                        alternative,
+                    )
+                )
+
+    return list_ending
 
 
 def ub_words_phrase_matcher_de(
@@ -1900,125 +2112,6 @@ def ub_words_phrase_matcher_de(
         list(df_sentence["Lemma"]),
         category,
     )
-
-
-def ignore_binary_inclusive_gendered_denom_analysis_de(
-    lang,
-    tokens,
-    false_positives,
-):
-    matches = fetch_matches(tokens, false_positives)
-    if matches.__len__() > 0:
-        old_start = 0
-        rest_text = []
-
-        for match_id, start, end in matches:
-            part = tokens[old_start:start]
-            rest_text.append(part.text)
-            old_start = end
-
-        docs = list(model[lang.lang].pipe(rest_text))
-        tokens = Doc.from_docs(docs)
-
-    return tokens
-
-
-def match_binary_inclusive_gendered_denom_analysis_de(
-    config: Config, false_positives, full_text, token, category, subcategory
-):
-    text = token.text
-    start = token.idx
-    if not ResultOut.genderedRolesFormatBinary(config.gendered_roles_format):
-        for false_positive in false_positives:
-            if not false_positive.endswith(text):
-                continue
-
-            new_start = start - len(false_positive.removesuffix(text))
-            if false_positive == full_text[new_start : new_start + len(false_positive)]:
-                start = new_start
-                text = false_positive
-
-                subcategory = "gendered_denominations_ending"
-                category = categories[subcategory]["category"]
-                break
-
-    return text, start, category, subcategory
-
-
-def find_article(tokens, i):
-    matches = 0
-    article_text = tokens[i - 1].text.lower()
-    gender = get_gender_of_word(tokens[i].text.lower())
-    if gender["definite_article"] != None:
-        for masculine, feminine, neuter, plural, alternative in articles:
-            if (
-                (gender["definite_article"] == "der" and article_text == masculine)
-                or (gender["definite_article"] == "die" and article_text == feminine)
-                or (gender["definite_article"] == "das" and article_text == neuter)
-            ):
-                match_masculine = masculine
-                match_feminine = feminine
-                match_neuter = neuter
-                match_plural = plural
-                match_alternative = alternative
-                matches += 1
-                if matches > 1:
-                    break
-
-        if matches == 1:
-            return (
-                match_masculine,
-                match_feminine,
-                match_neuter,
-                match_plural,
-                match_alternative,
-            )
-
-    return None, None, None, None, None
-
-
-def fetch_alternatives_with_article(tokens, i, alternatives):
-    alternatives_with_article = []
-    (
-        masculine,
-        feminine,
-        neuter,
-        plural,
-        alternative_for_article,
-    ) = find_article(tokens, i)
-
-    if alternative_for_article == None:
-        return None
-
-    # also detect if its a person or an institution
-    # in the later case do not offer the Gender-star options
-    # and use subcategory "misgendering_institutions"
-    for alternative in alternatives:
-        if "~" in alternative:
-            article_alternative = alternative_for_article
-        else:
-            if "---" in alternative:
-                (
-                    alternative,
-                    alternative_context,
-                ) = alternative.split("---")
-                alternative = alternative.strip()
-
-            words = alternative.split()
-            gender = get_gender_of_word(words[-1])
-
-            if gender["definite_article"] == "der":
-                article_alternative = masculine
-            elif gender["definite_article"] == "das":
-                article_alternative = neuter
-            elif gender["definite_article"] == "die" or alternative.endswith("in"):
-                article_alternative = feminine
-            else:
-                article_alternative = tokens[i - 1].text
-
-        alternatives_with_article.append(article_alternative + " " + alternative)
-
-    return alternatives_with_article
 
 
 def gendered_denom_analysis_de(
@@ -2101,18 +2194,6 @@ def gendered_denom_analysis_de(
                 )
 
     return list_tokens
-
-
-# Unified function for Empty words false positives and rules
-def is_conjunction(full_text, start=0):
-    if full_text in ["und", "oder", "and", "or"]:
-        return True
-
-    preceeding_text = full_text[max(0, start - 5) : start]
-    return (
-        re.search(r"^ *$", preceeding_text) != None
-        or re.search(r"[.!?:,]\s*$", preceeding_text, re.MULTILINE) != None
-    )
 
 
 def style_word_analysis_de(
@@ -2231,93 +2312,6 @@ def word_noun(
                 )
 
     return list_tokens
-
-
-# matcher to false positives
-def is_false_positive_match(list_false_positive, tokens, token):
-    if list_false_positive == None:
-        return False
-
-    for match_id, start, end in list_false_positive:
-        span_false = tokens[start:end]
-        if token.idx in range(span_false.start_char, span_false.end_char):
-            return True
-
-    return False
-
-
-# create false positives patterns based on false positives column
-def false_pattern_match(tokens):
-    # print ("Start:", tokens, [token.pos_ for token in tokens])
-    # list_false_positives = []
-
-    matcher = Matcher(model["en"].vocab)
-
-    # Define a list with nested dictionaries that contains the pattern to be matched
-    # pronoun_verb = [{'POS': 'PRON'}, {'POS': 'VERB'}]
-
-    # patterns for false positives
-
-    # master of + noun
-    pattern_master = [
-        [
-            {"LOWER": "master"},
-            {"LEMMA": "of"},
-            {"POS": {"IN": ["PRON", "NOUN", "PROPN"]}},
-        ],
-        [
-            {"LOWER": "masters"},
-            {"LEMMA": "of"},
-            {"POS": {"IN": ["PRON", "NOUN", "PROPN"]}},
-        ],
-    ]
-    matcher.add("FalsePositivesList", pattern_master)
-
-    # lead+someone(optional)+prepostion(on, down, up, to, away, back, along)
-    pattern_lead_prepos = [
-        [
-            {
-                "LEMMA": "lead",
-                "POS": "VERB",
-            },
-            {"POS": {"IN": ["PRON", "NOUN", "PROPN"]}, "OP": "?"},
-            {
-                "LEMMA": {
-                    "IN": [
-                        "on",
-                        "down",
-                        "up",
-                        "to",
-                        "away",
-                        "back",
-                        "along",
-                        "with",
-                        "off",
-                    ]
-                }
-            },
-        ]
-    ]
-    matcher.add("FalsePositivesList", pattern_lead_prepos)
-
-    # lead a (charmed, busy, quiet, normal, ...) life','lead your (my, his, her, their, our, ...) life'
-    pattern_lead_life = [
-        [
-            {"LEMMA": "lead", "POS": "VERB"},
-            {"POS": "DET", "OP": "?"},
-            {"POS": {"IN": ["ADJ", "PRON"]}, "OP": "?"},
-            {"LOWER": "life"},
-        ]
-    ]
-    matcher.add("FalsePositivesList", pattern_lead_life)
-
-    # need to
-    pattern_need_to = [
-        [{"LEMMA": "need", "POS": "VERB"}, {"LEMMA": {"IN": ["to", "for"]}}]
-    ]
-    matcher.add("FalsePositivesList", pattern_need_to)
-
-    return matcher(tokens)
 
 
 def rules_based_words_phrase_matcher(

--- a/app/main.py
+++ b/app/main.py
@@ -1233,7 +1233,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
         )
 
     if is_sub_category_enabled(config, "openly_discriminating"):
-        list_full += rules_based_words_phrase_matcher_de(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
@@ -1246,7 +1246,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
         )
 
     if is_sub_category_enabled(config, "gendered"):
-        list_full += rules_based_words_phrase_matcher_de(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
@@ -1308,7 +1308,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
         )
 
     if is_sub_category_enabled(config, "communal"):
-        list_full += rules_based_words_phrase_matcher_de(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
@@ -1318,11 +1318,12 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             None,
             [],
             "inclusive",
+            [],
             "communal",
         )
 
     if is_sub_category_enabled(config, "d_and_i"):
-        list_full += rules_based_words_phrase_matcher_de(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
@@ -1332,6 +1333,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             None,
             rules["de-DE"]["df_terms_d_and_i_words"],
             "inclusive",
+            [],
             "d_and_i",
         )
 
@@ -1435,45 +1437,45 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         )
 
     if is_sub_category_enabled(config, "openly_discriminating"):
-        list_full += rules_based_words_phrase_matcher_en(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
             text,
             tokens,
-            matches_false,
             words_data_en["od"],
             sentences_data_en["od"],
             rules[lang.locale]["df_open_dis_sentence"],
             "openly_discriminating",
+            matches_false,
         )
 
     if is_sub_category_enabled(config, "gendered"):
         if config.singular_they == SingularTheyType.ALL_PRONOUNS:
-            list_full += rules_based_words_phrase_matcher_en(
+            list_full += rules_based_words_phrase_matcher(
                 version,
                 config,
                 lang,
                 text,
                 tokens,
-                matches_false,
                 words_data_en["ge-singular-they"],
                 sentences_data_en["ge"],
                 rules[lang.locale]["df_gendered_sentence"],
                 "gendered",
+                matches_false,
             )
         else:
-            list_full += rules_based_words_phrase_matcher_en(
+            list_full += rules_based_words_phrase_matcher(
                 version,
                 config,
                 lang,
                 text,
                 tokens,
-                matches_false,
                 words_data_en["ge"],
                 sentences_data_en["ge"],
                 rules[lang.locale]["df_gendered_sentence"],
                 "gendered",
+                matches_false,
             )
         list_full += word_noun(
             version,
@@ -1487,45 +1489,45 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         )
 
     if is_sub_category_enabled(config, "inclusive"):
-        list_full += rules_based_words_phrase_matcher_en(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
             text,
             tokens,
-            matches_false,
             inclusive_words_data_en,
             inclusive_sentences_data_en,
             rules[lang.locale]["df_inclusive_sentence"],
             "inclusive",
+            matches_false,
         )
 
     if is_sub_category_enabled(config, "style"):
-        list_full += rules_based_words_phrase_matcher_en(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
             text,
             tokens,
-            matches_false,
             words_data_en["style"],
             sentences_data_en["style"],
             rules[lang.locale]["df_style_sentence"],
             "style",
+            matches_false,
         )
 
     if is_sub_category_enabled(config, "unconscious_bias"):
-        list_full += rules_based_words_phrase_matcher_en(
+        list_full += rules_based_words_phrase_matcher(
             version,
             config,
             lang,
             text,
             tokens,
-            matches_false,
             words_data_en["bias"],
             sentences_data_en["bias"],
             rules[lang.locale]["df_ub_sentence"],
             "unconscious_bias",
+            matches_false,
         ) + word_noun(
             version,
             config,
@@ -2160,7 +2162,7 @@ def word_noun(
     tokens,
     words_data,
     category,
-    matches_false=[],
+    matches_false=None,
 ):
     list_tokens = []
 
@@ -2215,72 +2217,11 @@ def word_noun(
     return list_tokens
 
 
-# Unified function for rules and sentence false positives
-
-# Unified function German
-def rules_based_words_phrase_matcher_de(
-    version: float,
-    config: Config,
-    lang,
-    full_text,
-    tokens,
-    words_data,
-    sentences_data,
-    df_sentence,
-    category,
-    fallback_subcategory=None,
-):
-    list_tokens = []
-
-    alternative = None
-    subcategory = fallback_subcategory
-
-    for token in tokens:
-        for word, word_type, *data in words_data:
-            if fetch_lemma_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
-                if isinstance(data, list):
-                    if len(data) >= 1:
-                        alternative = alternatives_declension(token, lang, data[0])
-                    if len(data) >= 2:
-                        subcategory = data[1]
-
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        token.idx + len(token.text),
-                        alternative,
-                    )
-                )
-
-    if isinstance(df_sentence, pd.DataFrame):
-        list_tokens += sentences_matcher(
-            version,
-            config,
-            lang,
-            full_text,
-            tokens,
-            sentences_data,
-            list(df_sentence["Lemma"]),
-            category,
-            fallback_subcategory,
-        )
-
-    return list_tokens
-
-
-# function English
-
 # matcher to false positives
 def is_false_positive_match(list_false_positive, tokens, token):
+    if list_false_positive == None:
+        return False
+
     for match_id, start, end in list_false_positive:
         span_false = tokens[start:end]
         if token.idx in range(span_false.start_char, span_false.end_char):
@@ -2363,20 +2304,23 @@ def false_pattern_match(tokens):
     return matcher(tokens)
 
 
-def rules_based_words_phrase_matcher_en(
+def rules_based_words_phrase_matcher(
     version: float,
     config: Config,
     lang,
     full_text,
     tokens,
-    matches_false,
     words_data,
     sentences_data,
     df_sentence,
     category,
+    matches_false=None,
+    fallback_subcategory=None,
 ):
     list_tokens = []
+
     alternative = None
+    subcategory = fallback_subcategory
 
     for token in tokens:
         for word, word_type, *data in words_data:
@@ -2385,12 +2329,18 @@ def rules_based_words_phrase_matcher_en(
                 and check_token_type(token, lang, word_type, True)
                 and is_false_positive_match(matches_false, tokens, token) == False
             ):
-                if len(data) > 1:
-                    alternative = ing_ify_alternatives(token, data[0])
-                    alternative = alternatives_declension(token, lang, alternative)
-                    subcategory = data[1]
-                else:
-                    subcategory = data[0]
+                if lang.lang == "en":
+                    if len(data) > 1:
+                        alternative = ing_ify_alternatives(token, data[0])
+                        alternative = alternatives_declension(token, lang, alternative)
+                        subcategory = data[1]
+                    else:
+                        subcategory = data[0]
+                elif lang.lang == "de":
+                    if len(data) >= 1:
+                        alternative = alternatives_declension(token, lang, data[0])
+                    if len(data) >= 2:
+                        subcategory = data[1]
 
                 list_tokens.append(
                     ResultOut.factory(
@@ -2407,16 +2357,20 @@ def rules_based_words_phrase_matcher_en(
                     )
                 )
 
-    return list_tokens + sentences_matcher(
-        version,
-        config,
-        lang,
-        full_text,
-        tokens,
-        sentences_data,
-        list(df_sentence["Lemma"]),
-        category,
-    )
+    if isinstance(df_sentence, pd.DataFrame):
+        list_tokens += sentences_matcher(
+            version,
+            config,
+            lang,
+            full_text,
+            tokens,
+            sentences_data,
+            list(df_sentence["Lemma"]),
+            category,
+            fallback_subcategory,
+        )
+
+    return list_tokens
 
 
 # english function to handle homonyms

--- a/app/main.py
+++ b/app/main.py
@@ -1180,10 +1180,10 @@ async def language_rules(
     return list_results
 
 
-def fetch_lemma_lower_cased(token, lang):
+def fetch_lemma(token, lang, lower_case=True):
     token_word = token.lemma_
 
-    if lang.lang == "en" or not check_token_type(token, lang, "s"):
+    if lower_case and (lang.lang == "en" or not check_token_type(token, lang, "s")):
         return token_word.lower()
 
     return token_word
@@ -1537,6 +1537,16 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
     return list_full
 
 
+def is_word_match(
+    token, tokens, lang, word, word_type, matches_false=None, lower_case=True
+):
+    return (
+        fetch_lemma(token, lang, lower_case) == word
+        and check_token_type(token, lang, word_type, True)
+        and is_false_positive_match(matches_false, tokens, token) == False
+    )
+
+
 """Function to catch the words related to False Positive in the user query"""
 
 
@@ -1692,16 +1702,17 @@ def alternatives_declension(token, lang, alternatives):
             "es",
             "e",
         ]
+    else:
+        return alternatives
 
-    if endings:
-        for ending in endings:
-            if not token.lemma_.endswith(ending) and token.text.endswith(ending):
-                return [
-                    alternative_declension(
-                        token.text, token_type, ending, lang, alternative
-                    ).strip()
-                    for alternative in alternatives
-                ]
+    for ending in endings:
+        if not token.lemma_.endswith(ending) and token.text.endswith(ending):
+            return [
+                alternative_declension(
+                    token.text, token_type, ending, lang, alternative
+                ).strip()
+                for alternative in alternatives
+            ]
 
     return alternatives
 
@@ -1798,6 +1809,7 @@ def sentences_matcher(
     matches = fetch_matches(tokens, sentences_list)
     for match_id, start, end in matches:
         span = tokens[start:end]
+
         if sentences_data == None:
             list_tokens.append(
                 ResultOut.factory(
@@ -1858,25 +1870,25 @@ def ub_words_phrase_matcher_de(
 
     for token in tokens:
         for word, word_type, alternative, subcategory in words_data:
-            if fetch_lemma_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
-                alternative = alternatives_declension(token, lang, alternative)
+            if not is_word_match(token, tokens, lang, word, word_type):
+                continue
 
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        token.idx + len(token.text),
-                        alternative,
-                    )
+            alternative = alternatives_declension(token, lang, alternative)
+
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    token.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    token.idx,
+                    token.idx + len(token.text),
+                    alternative,
                 )
+            )
 
     return list_tokens + sentences_matcher(
         version,
@@ -1965,6 +1977,50 @@ def find_article(tokens, i):
     return None, None, None, None, None
 
 
+def fetch_alternatives_with_article(tokens, i, alternatives):
+    alternatives_with_article = []
+    (
+        masculine,
+        feminine,
+        neuter,
+        plural,
+        alternative_for_article,
+    ) = find_article(tokens, i)
+
+    if alternative_for_article == None:
+        return None
+
+    # also detect if its a person or an institution
+    # in the later case do not offer the Gender-star options
+    # and use subcategory "misgendering_institutions"
+    for alternative in alternatives:
+        if "~" in alternative:
+            article_alternative = alternative_for_article
+        else:
+            if "---" in alternative:
+                (
+                    alternative,
+                    alternative_context,
+                ) = alternative.split("---")
+                alternative = alternative.strip()
+
+            words = alternative.split()
+            gender = get_gender_of_word(words[-1])
+
+            if gender["definite_article"] == "der":
+                article_alternative = masculine
+            elif gender["definite_article"] == "das":
+                article_alternative = neuter
+            elif gender["definite_article"] == "die" or alternative.endswith("in"):
+                article_alternative = feminine
+            else:
+                article_alternative = tokens[i - 1].text
+
+        alternatives_with_article.append(article_alternative + " " + alternative)
+
+    return alternatives_with_article
+
+
 def gendered_denom_analysis_de(
     version: float,
     config: Config,
@@ -2003,82 +2059,46 @@ def gendered_denom_analysis_de(
                         token_morph_number, alternatives_sing, alternatives_plur
                     )
 
-                if alternatives != None:
-                    (
-                        text,
-                        start,
-                        category,
-                        subcategory,
-                    ) = match_binary_inclusive_gendered_denom_analysis_de(
+                if alternatives == None:
+                    continue
+
+                (
+                    text,
+                    start,
+                    category,
+                    subcategory,
+                ) = match_binary_inclusive_gendered_denom_analysis_de(
+                    config,
+                    false_positives,
+                    full_text,
+                    tokens[i],
+                    category,
+                    subcategory,
+                )
+
+                if i > 0 and token_morph_number[0] == "Sing":
+                    alternatives_with_article = fetch_alternatives_with_article(
+                        tokens, i, alternatives
+                    )
+                    if alternatives_with_article != None:
+                        alternatives = alternatives_with_article
+                        start = tokens[i - 1].idx
+                        text = tokens[i - 1].text + " " + text
+
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
                         config,
-                        false_positives,
+                        lang,
+                        text,
                         full_text,
-                        tokens[i],
                         category,
                         subcategory,
+                        start,
+                        None,
+                        alternatives,
                     )
-
-                    if i > 0 and token_morph_number[0] == "Sing":
-                        alternatives_with_article = []
-                        (
-                            masculine,
-                            feminine,
-                            neuter,
-                            plural,
-                            alternative_for_article,
-                        ) = find_article(tokens, i)
-
-                        if alternative_for_article != None:
-                            # also detect if its a person or an institution
-                            # in the later case do not offer the Gender-star options
-                            # and use subcategory "misgendering_institutions"
-                            for alternative in alternatives:
-                                if "~" in alternative:
-                                    article_alternative = alternative_for_article
-                                else:
-                                    if "---" in alternative:
-                                        (
-                                            alternative,
-                                            alternative_context,
-                                        ) = alternative.split("---")
-                                        alternative = alternative.strip()
-
-                                    words = alternative.split()
-                                    gender = get_gender_of_word(words[-1])
-
-                                    if gender["definite_article"] == "der":
-                                        article_alternative = masculine
-                                    elif gender["definite_article"] == "das":
-                                        article_alternative = neuter
-                                    elif gender[
-                                        "definite_article"
-                                    ] == "die" or alternative.endswith("in"):
-                                        article_alternative = feminine
-                                    else:
-                                        article_alternative = tokens[i - 1].text
-
-                                alternatives_with_article.append(
-                                    article_alternative + " " + alternative
-                                )
-
-                            alternatives = alternatives_with_article
-                            start = tokens[i - 1].idx
-                            text = tokens[i - 1].text + " " + text
-
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            text,
-                            full_text,
-                            category,
-                            subcategory,
-                            start,
-                            None,
-                            alternatives,
-                        )
-                    )
+                )
 
     return list_tokens
 
@@ -2120,23 +2140,25 @@ def style_word_analysis_de(
             continue
 
         for word, word_type, alternative, subcategory in words_data:
-            if token.lemma_ == word and check_token_type(token, lang, word_type, True):
-                alternative = alternatives_declension(token, lang, alternative)
+            if not is_word_match(token, tokens, lang, word, word_type, None, False):
+                continue
 
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        None,
-                        alternative,
-                    )
+            alternative = alternatives_declension(token, lang, alternative)
+
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    token.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    token.idx,
+                    None,
+                    alternative,
                 )
+            )
 
     return list_tokens + sentences_matcher(
         version,
@@ -2171,44 +2193,42 @@ def word_noun(
             subcategory,
             *data,
         ) in words_data:
-            if (
-                fetch_lemma_lower_cased(token, lang) == word
-                and check_token_type(token, lang, word_type, True)
-                and is_false_positive_match(matches_false, tokens, token) == False
-            ):
-                token_morph_number = token.morph.get("Number")
-                if is_number_list_empty(token_morph_number, token, full_text):
-                    continue
+            if not is_word_match(token, tokens, lang, word, word_type, matches_false):
+                continue
 
-                if lang.lang == "de":
-                    alternative = plural_or_singular_alternatives_de(
-                        token_morph_number, alternative_sing, alternative_plur
-                    )
-                else:
-                    alternative, subcategory = plural_or_singular_en(
-                        token,
-                        token_morph_number,
-                        alternative_sing,
-                        alternative_plur,
+            token_morph_number = token.morph.get("Number")
+            if is_number_list_empty(token_morph_number, token, full_text):
+                continue
+
+            if lang.lang == "de":
+                alternative = plural_or_singular_alternatives_de(
+                    token_morph_number, alternative_sing, alternative_plur
+                )
+            elif lang.lang == "en":
+                alternative, subcategory = plural_or_singular_en(
+                    token,
+                    token_morph_number,
+                    alternative_sing,
+                    alternative_plur,
+                    subcategory,
+                    data[0],
+                )
+
+            if alternative != None:
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        token.text,
+                        full_text,
+                        category,
                         subcategory,
-                        data[0],
+                        token.idx,
+                        token.idx + len(token.text),
+                        alternative,
                     )
-
-                if alternative != None:
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            alternative,
-                        )
-                    )
+                )
 
     return list_tokens
 
@@ -2320,38 +2340,36 @@ def rules_based_words_phrase_matcher(
 
     for token in tokens:
         for word, word_type, *data in words_data:
-            if (
-                fetch_lemma_lower_cased(token, lang) == word
-                and check_token_type(token, lang, word_type, True)
-                and is_false_positive_match(matches_false, tokens, token) == False
-            ):
-                if lang.lang == "en":
-                    if len(data) > 1:
-                        alternative = ing_ify_alternatives(token, data[0])
-                        alternative = alternatives_declension(token, lang, alternative)
-                        subcategory = data[1]
-                    else:
-                        subcategory = data[0]
-                elif lang.lang == "de":
-                    if len(data) >= 1:
-                        alternative = alternatives_declension(token, lang, data[0])
-                    if len(data) >= 2:
-                        subcategory = data[1]
+            if not is_word_match(token, tokens, lang, word, word_type, matches_false):
+                continue
 
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        token.idx + len(token.text),
-                        alternative,
-                    )
+            if lang.lang == "en":
+                if len(data) > 1:
+                    alternative = ing_ify_alternatives(token, data[0])
+                    alternative = alternatives_declension(token, lang, alternative)
+                    subcategory = data[1]
+                else:
+                    subcategory = data[0]
+            elif lang.lang == "de":
+                if len(data) >= 1:
+                    alternative = alternatives_declension(token, lang, data[0])
+                if len(data) >= 2:
+                    subcategory = data[1]
+
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    token.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    token.idx,
+                    token.idx + len(token.text),
+                    alternative,
                 )
+            )
 
     if isinstance(df_sentence, pd.DataFrame):
         list_tokens += sentences_matcher(
@@ -2386,27 +2404,27 @@ def homonyms_en(
             if not is_sub_category_enabled(config, subcategory):
                 continue
 
-            if (
-                token.lemma_ == word
-                and check_token_type(token, lang, word_type, True)
-                and is_false_positive_match(matches_false, tokens, token) == False
+            if not is_word_match(
+                token, tokens, lang, word, word_type, matches_false, False
             ):
-                alternative = ing_ify_alternatives(token, alternative)
+                continue
 
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        token.idx + len(token.text),
-                        alternative,
-                    )
+            alternative = ing_ify_alternatives(token, alternative)
+
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    token.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    token.idx,
+                    token.idx + len(token.text),
+                    alternative,
                 )
+            )
 
     return list_tokens
 
@@ -2433,40 +2451,42 @@ def literal_match(
             *explanation,
         ) in term_list:
             span = tokens[start:end]
-            if span.text == term:
-                url = None
-                icon = None
-                explanation_text = None
+            if span.text != term:
+                continue
 
-                if (
-                    isinstance(explanation, list)
-                    and len(explanation)
-                    and isinstance(explanation[0], dict)
-                ):
-                    explanation_text = (
-                        explanation[0]["text"] if "text" in explanation[0] else None
-                    )
-                    url = explanation[0]["url"] if "url" in explanation[0] else None
-                    icon = explanation[0]["icon"] if "icon" in explanation[0] else None
+            url = None
+            icon = None
+            explanation_text = None
 
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start_char,
-                        span.end_char,
-                        alternative,
-                        None,
-                        explanation_text,
-                        url,
-                        icon,
-                    )
+            if (
+                isinstance(explanation, list)
+                and len(explanation)
+                and isinstance(explanation[0], dict)
+            ):
+                explanation_text = (
+                    explanation[0]["text"] if "text" in explanation[0] else None
                 )
+                url = explanation[0]["url"] if "url" in explanation[0] else None
+                icon = explanation[0]["icon"] if "icon" in explanation[0] else None
+
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    span.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    span.start_char,
+                    span.end_char,
+                    alternative,
+                    None,
+                    explanation_text,
+                    url,
+                    icon,
+                )
+            )
 
     return list_tokens
 

--- a/app/main.py
+++ b/app/main.py
@@ -112,7 +112,7 @@ bolt_handler = AsyncSlackRequestHandler(bolt)
 @bolt.command("/witty")
 async def handle_command_witty(
     body: dict, ack: Ack, respond: Respond, client: WebClient
-):
+):  # pragma: no cover
     await ack()
 
     user_request_in = RequestIn(text=body["text"])
@@ -237,7 +237,7 @@ for language in languages:
 
 def fetch_current_username(
     credentials: Optional[HTTPBasicCredentials] = Depends(security),
-):
+):  # pragma: no cover
     # Credentials are missing
     if credentials is None:
         # Auth is disabled, just proceed
@@ -274,7 +274,7 @@ def fetch_current_username(
 
 
 @app.post("/slack/commands")
-async def post_slack_commands(request: Request):
+async def post_slack_commands(request: Request):  # pragma: no cover
     return await bolt_handler.handle(request)
 
 
@@ -690,10 +690,6 @@ def is_number_list_empty(number, token, full_text):
     return False
 
 
-def filter_config(config):
-    return {k: v for (k, v) in config.items() if v != "" and v is not None and v != []}
-
-
 def apply_rules(user_request_in: RequestIn, configs: dict, plan: str):
     disabled_categories = user_request_in.config.disabled_categories
 
@@ -772,7 +768,7 @@ def fetch_user(request: Request):
                 status_code=status.HTTP_403_FORBIDDEN, detail="access token invalid"
             )
 
-        try:
+        try:  # pragma: no cover
             if claims["aud"] != settings.aadb2c_client_id:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
@@ -798,7 +794,7 @@ def fetch_user(request: Request):
     if settings.testing:
         if "x-auth" in request.headers:
             return request.headers["x-auth"]
-        if settings.redis_default_user:
+        if settings.redis_default_user:  # pragma: no cover
             return settings.redis_default_user
 
     return None
@@ -832,7 +828,7 @@ async def check(
     response: Response,
     user_request_in: RequestIn,
 ):
-    if version != 1.1 and version != 2.0:
+    if version != 1.1 and version != 2.0:  # pragma: no cover
         response.status_code = status.HTTP_400_BAD_REQUEST
         return Result.factory("Version not supported: " + str(version))
 
@@ -1070,7 +1066,7 @@ async def languagetool_rules(version: float, config: Config, lang: Language, tex
                 list_results = languagetool_matches(
                     version, config, lang, "orthography", text, result
                 )
-            except ClientError as err:
+            except ClientError as err:  # pragma: no cover
                 result = "Problem communicating with LanguageTool"
                 if r.status >= 500:
                     try:
@@ -1203,7 +1199,7 @@ def check_category_importance(config: Config, subcategory: str):
 
 
 def is_sub_category_enabled(config: Config, subcategory: str):
-    if subcategory not in categories:
+    if subcategory not in categories:  # pragma: no cover
         if not settings.is_prod:
             logging.error(
                 "Subcategory is not defined: %s",
@@ -2478,7 +2474,7 @@ def literal_match(
 # want to server to run app.py in the folder app as main app, port=8000 is defaut port for the fast api
 # reload=True is debag mode in Flask is on, to set =False, when deploy the app to the production
 # might be added host="0.0.0.0"
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     # If this is being ran directly as a script, run an internal uvicorn server
     # to service API requests
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level=settings.logging_config_level)

--- a/app/main.py
+++ b/app/main.py
@@ -313,8 +313,8 @@ def openapi(username: str = Depends(get_current_username)):  # pragma: no cover
 
 # public routes
 @app.get("/", include_in_schema=False)
-def root():
-    url = "https://www.witty.works/form"
+def get_root():
+    url = "https://www.witty.works/editor"
     status_code = 301
 
     if not settings.is_prod and settings.testing == False:  # pragma: no cover
@@ -430,11 +430,6 @@ async def auth_2_0(request: Request, response: Response):
         )
 
     return get_result_conf(rules, 2.0)
-
-
-@app.get("/form", include_in_schema=False)
-def form():
-    return root()
 
 
 @app.get(

--- a/app/main.py
+++ b/app/main.py
@@ -1244,8 +1244,8 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             lang,
             text,
             tokens,
-            open_disc_words_alternatives,
-            open_disc_sentences_alternatives,
+            open_disc_words_data,
+            open_disc_sentences_data,
             rules["de-DE"]["df_open_dis_sentence"],
             "openly_discriminating",
         )
@@ -1257,8 +1257,8 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             lang,
             text,
             tokens,
-            gender_words_alternatives_no_noun,
-            gender_sentences_alternatives,
+            gender_words_data_no_noun,
+            gender_sentences_data,
             rules["de-DE"]["df_gendered_sentences"],
             "gendered",
         ) + gendered_denom_analysis_de(
@@ -1267,7 +1267,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             lang,
             text,
             tokens,
-            gender_words_alternatives,
+            gender_words_data,
             false_positives.gender,
         )
 
@@ -1298,8 +1298,8 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             lang,
             text,
             tokens,
-            bias_words_alternatives_no_plur,
-            bias_sentences_alternatives,
+            bias_words_data_no_plur,
+            bias_sentences_data,
             rules["de-DE"]["df_ub_sentences"],
             "unconscious_bias",
         ) + agentic_language_analysis_de(
@@ -1308,7 +1308,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             lang,
             text,
             tokens,
-            bias_words_alternatives_noun,
+            bias_words_data_noun,
             "unconscious_bias",
         )
 
@@ -1360,8 +1360,8 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             text,
             tokens,
             rules["de-DE"]["terms_style"],
-            style_words_alternatives,
-            style_sentences_alternatives,
+            style_words_data,
+            style_sentences_data,
             false_positives.style,
         )
 
@@ -1372,51 +1372,51 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
 def english_rules(version: float, config: Config, lang: Language, tokens, text: str):
     list_full = []
 
-    words_alternatives_en = defaultdict(list)
-    inclusive_words_alternatives_en = []
-    gendered_words_alternatives_en = defaultdict(list)
-    inclusive_sentences_alternatives_en = []
-    sentences_alternatives_en = defaultdict(list)
+    words_data_en = defaultdict(list)
+    inclusive_words_data_en = []
+    gendered_words_data_en = defaultdict(list)
+    inclusive_sentences_data_en = []
+    sentences_data_en = defaultdict(list)
     matches_false = fetch_false_positive_matcher(tokens)
 
     if lang.locale == "en-GB":
-        words_alternatives_en["od"] = open_disc_words_alternatives_GB
-        words_alternatives_en["ge"] = gender_words_alternatives_GB
-        words_alternatives_en["ge-singular-they"] = (
-            gender_words_alternatives_GB + bias_singular_they_alternatives_GB
+        words_data_en["od"] = open_disc_words_data_GB
+        words_data_en["ge"] = gender_words_data_GB
+        words_data_en["ge-singular-they"] = (
+            gender_words_data_GB + bias_singular_they_alternatives_GB
         )
-        words_alternatives_en["style"] = style_words_alternatives_GB
-        words_alternatives_en["bias"] = bias_words_alternatives_GB
-        words_alternatives_en["homonym"] = homonyms_word_GB
-        words_alternatives_en["abbr"] = abbreviation_GB
+        words_data_en["style"] = style_words_data_GB
+        words_data_en["bias"] = bias_words_data_GB
+        words_data_en["homonym"] = homonyms_word_GB
+        words_data_en["abbr"] = abbreviation_GB
 
-        inclusive_words_alternatives_en = inclusive_words_alternatives_GB
-        gendered_words_alternatives_en["gendered"] = gender_noun_words_alternatives_GB
-        gendered_words_alternatives_en["bias"] = gender_bias_words_alternatives_GB
-        inclusive_sentences_alternatives_en = inclusive_sentences_alternatives_GB
-        sentences_alternatives_en["od"] = open_dis_sentences_GB
-        sentences_alternatives_en["ge"] = gender_sentences_alternatives_GB
-        sentences_alternatives_en["style"] = style_sentences_alternatives_GB
-        sentences_alternatives_en["bias"] = bias_sentences_alternatives_GB
+        inclusive_words_data_en = inclusive_words_data_GB
+        gendered_words_data_en["gendered"] = gender_noun_words_data_GB
+        gendered_words_data_en["bias"] = gender_bias_words_data_GB
+        inclusive_sentences_data_en = inclusive_sentences_data_GB
+        sentences_data_en["od"] = open_dis_sentences_GB
+        sentences_data_en["ge"] = gender_sentences_data_GB
+        sentences_data_en["style"] = style_sentences_data_GB
+        sentences_data_en["bias"] = bias_sentences_data_GB
     else:
-        words_alternatives_en["od"] = open_disc_words_alternatives_US
-        words_alternatives_en["ge"] = gender_words_alternatives_US
-        words_alternatives_en["ge-singular-they"] = (
-            gender_words_alternatives_US + bias_singular_they_alternatives_US
+        words_data_en["od"] = open_disc_words_data_US
+        words_data_en["ge"] = gender_words_data_US
+        words_data_en["ge-singular-they"] = (
+            gender_words_data_US + bias_singular_they_alternatives_US
         )
-        words_alternatives_en["style"] = style_words_alternatives_US
-        words_alternatives_en["bias"] = bias_words_alternatives_US
-        words_alternatives_en["homonym"] = homonyms_word_US
-        words_alternatives_en["abbr"] = abbreviation_US
+        words_data_en["style"] = style_words_data_US
+        words_data_en["bias"] = bias_words_data_US
+        words_data_en["homonym"] = homonyms_word_US
+        words_data_en["abbr"] = abbreviation_US
 
-        inclusive_words_alternatives_en = inclusive_words_alternatives_US
-        gendered_words_alternatives_en["gendered"] = gender_noun_words_alternatives_US
-        gendered_words_alternatives_en["bias"] = gender_bias_words_alternatives_US
-        inclusive_sentences_alternatives_en = inclusive_sentences_alternatives_US
-        sentences_alternatives_en["od"] = open_dis_sentences_US
-        sentences_alternatives_en["ge"] = gender_sentences_alternatives_US
-        sentences_alternatives_en["style"] = style_sentences_alternatives_US
-        sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
+        inclusive_words_data_en = inclusive_words_data_US
+        gendered_words_data_en["gendered"] = gender_noun_words_data_US
+        gendered_words_data_en["bias"] = gender_bias_words_data_US
+        inclusive_sentences_data_en = inclusive_sentences_data_US
+        sentences_data_en["od"] = open_dis_sentences_US
+        sentences_data_en["ge"] = gender_sentences_data_US
+        sentences_data_en["style"] = style_sentences_data_US
+        sentences_data_en["bias"] = bias_sentences_data_US
 
     list_full += homonyms_en(
         version,
@@ -1425,7 +1425,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         text,
         tokens,
         matches_false,
-        words_alternatives_en["homonym"],
+        words_data_en["homonym"],
     )
 
     if is_sub_category_enabled(config, "abbreviation"):
@@ -1436,7 +1436,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             rules[lang.locale]["df_abbreviation"],
-            words_alternatives_en["abbr"],
+            words_data_en["abbr"],
         )
 
     if is_sub_category_enabled(config, "openly_discriminating"):
@@ -1447,8 +1447,8 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             matches_false,
-            words_alternatives_en["od"],
-            sentences_alternatives_en["od"],
+            words_data_en["od"],
+            sentences_data_en["od"],
             rules[lang.locale]["df_open_dis_sentence"],
             "openly_discriminating",
         )
@@ -1462,8 +1462,8 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
                 text,
                 tokens,
                 matches_false,
-                words_alternatives_en["ge-singular-they"],
-                sentences_alternatives_en["ge"],
+                words_data_en["ge-singular-they"],
+                sentences_data_en["ge"],
                 rules[lang.locale]["df_gendered_sentence"],
                 "gendered",
             )
@@ -1475,8 +1475,8 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
                 text,
                 tokens,
                 matches_false,
-                words_alternatives_en["ge"],
-                sentences_alternatives_en["ge"],
+                words_data_en["ge"],
+                sentences_data_en["ge"],
                 rules[lang.locale]["df_gendered_sentence"],
                 "gendered",
             )
@@ -1487,7 +1487,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             matches_false,
-            gendered_words_alternatives_en["gendered"],
+            gendered_words_data_en["gendered"],
             "gendered",
         )
 
@@ -1499,8 +1499,8 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             matches_false,
-            inclusive_words_alternatives_en,
-            inclusive_sentences_alternatives_en,
+            inclusive_words_data_en,
+            inclusive_sentences_data_en,
             rules[lang.locale]["df_inclusive_sentence"],
             "inclusive",
         )
@@ -1513,8 +1513,8 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             matches_false,
-            words_alternatives_en["style"],
-            sentences_alternatives_en["style"],
+            words_data_en["style"],
+            sentences_data_en["style"],
             rules[lang.locale]["df_style_sentence"],
             "style",
         )
@@ -1527,8 +1527,8 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             matches_false,
-            words_alternatives_en["bias"],
-            sentences_alternatives_en["bias"],
+            words_data_en["bias"],
+            sentences_data_en["bias"],
             rules[lang.locale]["df_ub_sentence"],
             "unconscious_bias",
         ) + gendered_en(
@@ -1538,7 +1538,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             text,
             tokens,
             matches_false,
-            gendered_words_alternatives_en["bias"],
+            gendered_words_data_en["bias"],
             "unconscious_bias",
         )
     return list_full
@@ -1793,7 +1793,7 @@ def sentences_matcher(
     lang,
     full_text,
     tokens,
-    sentences_alternatives,
+    sentences_data,
     sentences_list,
     category,
     fallback_subcategory=None,
@@ -1805,7 +1805,7 @@ def sentences_matcher(
     matches = fetch_matches(tokens, sentences_list)
     for match_id, start, end in matches:
         span = tokens[start:end]
-        if sentences_alternatives == None:
+        if sentences_data == None:
             list_tokens.append(
                 ResultOut.factory(
                     version,
@@ -1821,13 +1821,12 @@ def sentences_matcher(
                 )
             )
         else:
-            for sentence, *data in sentences_alternatives:
+            for sentence, *data in sentences_data:
                 if span.text.lower() == sentence.lower():
+                    if len(data) >= 1:
+                        alternative = data[0]
                     if len(data) >= 2:
-                        alternative = data[0]
                         subcategory = data[1]
-                    elif len(data) >= 1:
-                        alternative = data[0]
 
                     list_tokens.append(
                         ResultOut.factory(
@@ -1857,7 +1856,7 @@ def agentic_language_analysis_de(
     lang,
     full_text,
     tokens,
-    words_alternatives,
+    words_data,
     category,
 ):
     list_tokens = []
@@ -1869,7 +1868,7 @@ def agentic_language_analysis_de(
             alternative_sing,
             alternative_plur,
             subcategory,
-        ) in words_alternatives:
+        ) in words_data:
             if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
                 token, lang, word_type, True
             ):
@@ -1906,18 +1905,18 @@ def ub_words_phrase_matcher_de(
     lang,
     full_text,
     tokens,
-    words_alternatives,
-    sentences_alternatives,
+    words_data,
+    sentences_data,
     df_sentence,
     category,
 ):
     list_tokens = []
 
     for token in tokens:
-        for word, word_type, alternative, subcategory in words_alternatives:
-            if fetch_lemma_non_noun_lower_cased(
-                token, lang
-            ) == word and check_token_type(token, lang, word_type, True):
+        for word, word_type, alternative, subcategory in words_data:
+            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
+                token, lang, word_type, True
+            ):
                 alternative = alternatives_declension(token, lang, alternative)
 
                 list_tokens.append(
@@ -1941,7 +1940,7 @@ def ub_words_phrase_matcher_de(
         lang,
         full_text,
         tokens,
-        sentences_alternatives,
+        sentences_data,
         list(df_sentence["Lemma"]),
         category,
     )
@@ -2028,7 +2027,7 @@ def gendered_denom_analysis_de(
     lang,
     full_text,
     tokens,
-    words_alternatives,
+    words_data,
     false_positives,
 ):
     category = "gendered"
@@ -2048,7 +2047,7 @@ def gendered_denom_analysis_de(
             alternatives_plur,
             alternatives_all,
             subcategory,
-        ) in words_alternatives:
+        ) in words_data:
             if tokens[i].lemma_ == word and check_token_type(
                 tokens[i], lang, word_type, True
             ):
@@ -2159,8 +2158,8 @@ def style_word_analysis_de(
     full_text,
     tokens,
     df_sentences,
-    words_alternatives,
-    sentences_alternatives,
+    words_data,
+    sentences_data,
     false_positives,
 ):
     category = "style"
@@ -2176,7 +2175,7 @@ def style_word_analysis_de(
         if token.lemma_ == "aber" and is_conjunction(full_text, token.idx):
             continue
 
-        for word, word_type, alternative, subcategory in words_alternatives:
+        for word, word_type, alternative, subcategory in words_data:
             if token.lemma_ == word and check_token_type(token, lang, word_type, True):
                 alternative = alternatives_declension(token, lang, alternative)
 
@@ -2201,7 +2200,7 @@ def style_word_analysis_de(
         lang,
         full_text,
         tokens,
-        sentences_alternatives,
+        sentences_data,
         df_sentences,
         category,
     )
@@ -2216,7 +2215,7 @@ def word_noun_de(
     lang,
     full_text,
     tokens,
-    words_alternatives,
+    words_data,
     category,
 ):
     list_tokens = []
@@ -2228,7 +2227,7 @@ def word_noun_de(
             alternative_sing,
             alternative_plur,
             subcategory,
-        ) in words_alternatives:
+        ) in words_data:
             if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
                 token, lang, word_type, True
             ):
@@ -2268,8 +2267,8 @@ def rules_based_words_phrase_matcher_de(
     lang,
     full_text,
     tokens,
-    words_alternatives,
-    sentences_alternatives,
+    words_data,
+    sentences_data,
     df_sentence,
     category,
     fallback_subcategory=None,
@@ -2280,10 +2279,10 @@ def rules_based_words_phrase_matcher_de(
     subcategory = fallback_subcategory
 
     for token in tokens:
-        for word, word_type, *data in words_alternatives:
-            if fetch_lemma_non_noun_lower_cased(
-                token, lang
-            ) == word and check_token_type(token, lang, word_type, True):
+        for word, word_type, *data in words_data:
+            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
+                token, lang, word_type, True
+            ):
                 if isinstance(data, list):
                     if len(data) >= 1:
                         alternative = alternatives_declension(token, lang, data[0])
@@ -2312,7 +2311,7 @@ def rules_based_words_phrase_matcher_de(
             lang,
             full_text,
             tokens,
-            sentences_alternatives,
+            sentences_data,
             list(df_sentence["Lemma"]),
             category,
             fallback_subcategory,
@@ -2414,8 +2413,8 @@ def rules_based_words_phrase_matcher_en(
     full_text,
     tokens,
     matches_false,
-    words_alternatives,
-    sentences_alternatives,
+    words_data,
+    sentences_data,
     df_sentence,
     category,
 ):
@@ -2423,7 +2422,7 @@ def rules_based_words_phrase_matcher_en(
     alternative = None
 
     for token in tokens:
-        for word, word_type, *data in words_alternatives:
+        for word, word_type, *data in words_data:
             if (
                 fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
@@ -2457,7 +2456,7 @@ def rules_based_words_phrase_matcher_en(
         lang,
         full_text,
         tokens,
-        sentences_alternatives,
+        sentences_data,
         list(df_sentence["Lemma"]),
         category,
     )
@@ -2471,12 +2470,12 @@ def homonyms_en(
     full_text,
     tokens,
     matches_false,
-    words_alternatives,
+    words_data,
 ):
     list_tokens = []
 
     for token in tokens:
-        for word, word_type, category, subcategory, alternative in words_alternatives:
+        for word, word_type, category, subcategory, alternative in words_data:
             if not is_sub_category_enabled(config, subcategory):
                 continue
 
@@ -2575,7 +2574,7 @@ def gendered_en(
     full_text,
     tokens,
     matches_false,
-    words_alternatives,
+    words_data,
     category,
 ):
     list_tokens = []
@@ -2588,7 +2587,7 @@ def gendered_en(
             alternative_plur,
             subcategory,
             second_subcategory,
-        ) in words_alternatives:
+        ) in words_data:
             if (
                 fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)

--- a/app/main.py
+++ b/app/main.py
@@ -116,7 +116,7 @@ async def handle_command_witty(
     await ack()
 
     user_request_in = RequestIn(text=body["text"])
-    text, lang, limit_reached = get_text(user_request_in)
+    text, lang, limit_reached = fetch_text(user_request_in)
 
     if lang == None:
         await respond(f"Witty could not determine a language for '{text}'.")
@@ -235,7 +235,7 @@ for language in languages:
         )
 
 
-def get_current_username(
+def fetch_current_username(
     credentials: Optional[HTTPBasicCredentials] = Depends(security),
 ):
     # Credentials are missing
@@ -274,7 +274,7 @@ def get_current_username(
 
 
 @app.post("/slack/commands")
-async def slack_commands(request: Request):
+async def post_slack_commands(request: Request):
     return await bolt_handler.handle(request)
 
 
@@ -283,10 +283,10 @@ async def slack_commands(request: Request):
     "/exception",
     include_in_schema=not settings.is_prod,
 )
-async def exception(
+async def post_exception(
     request: Request,
     user_request_in: RequestIn,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):  # pragma: no cover
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=user_request_in.text
@@ -294,20 +294,20 @@ async def exception(
 
 
 @app.get("/lt", include_in_schema=not settings.is_prod)
-def get_lt(username: str = Depends(get_current_username)):
+def get_lt(username: str = Depends(fetch_current_username)):
     return languagetool_url
 
 
 @app.get("/docs", include_in_schema=False)
 def get_swagger_documentation(
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
     include_in_schema=not settings.is_prod,
 ):  # pragma: no cover
     return get_swagger_ui_html(openapi_url="/openapi.json", title="docs")
 
 
 @app.get("/openapi.json", include_in_schema=False)
-def openapi(username: str = Depends(get_current_username)):  # pragma: no cover
+def get_openapi(username: str = Depends(fetch_current_username)):  # pragma: no cover
     return get_openapi(title=app.title, version=app.version, routes=app.routes)
 
 
@@ -328,8 +328,8 @@ def get_root():
     "/save_openapi_json",
     include_in_schema=not settings.is_prod,
 )
-def save_openapi_json(
-    username: str = Depends(get_current_username),
+def get_save_openapi_json(
+    username: str = Depends(fetch_current_username),
 ):  # pragma: no cover
     openapi_data = app.openapi()
     for path in openapi_data["paths"].copy():
@@ -344,10 +344,10 @@ def save_openapi_json(
     "/debug/german_gender_ending",
     include_in_schema=not settings.is_prod,
 )
-def german_gender_ending(
+def get_german_gender_ending(
     alternative: str,
     german_gender_ending: GermanGenderEndingType = None,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     alternative_variations = set()
 
@@ -370,8 +370,10 @@ def german_gender_ending(
     include_in_schema=not settings.is_prod,
     dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
-async def auth_debug(request: Request, user_request_in: RequestIn):  # pragma: no cover
-    user_email = get_user(request)
+async def post_auth_debug(
+    request: Request, user_request_in: RequestIn
+):  # pragma: no cover
+    user_email = fetch_user(request)
     if not user_email:
         return user_email
 
@@ -397,13 +399,13 @@ async def auth_debug(request: Request, user_request_in: RequestIn):  # pragma: n
     response_model_exclude_none=True,
     dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
-async def auth_1_1(request: Request, response: Response):
-    user_email = get_user(request)
+async def post_auth_1_1(request: Request, response: Response):
+    user_email = fetch_user(request)
     if not user_email:
         return None
 
     rules = await fetch_rules_for_request(RequestIn(text=""), user_email)
-    config = get_result_conf(rules, 1.1)
+    config = fetch_result_conf(rules, 1.1)
     if config == None and user_email:
         config = {}
 
@@ -416,8 +418,8 @@ async def auth_1_1(request: Request, response: Response):
     response_model_exclude_none=True,
     dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
-async def auth_2_0(request: Request, response: Response):
-    user_email = get_user(request)
+async def post_auth_2_0(request: Request, response: Response):
+    user_email = fetch_user(request)
     if not user_email:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -429,16 +431,16 @@ async def auth_2_0(request: Request, response: Response):
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
-    return get_result_conf(rules, 2.0)
+    return fetch_result_conf(rules, 2.0)
 
 
 @app.get(
     "/debug/spacy",
     include_in_schema=not settings.is_prod,
 )
-async def debug_spacy(
+async def get_debug_spacy(
     text: str,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     locale = lang_detection.get_locale(
         text,
@@ -449,7 +451,7 @@ async def debug_spacy(
     lang = Language(locale)
 
     results = []
-    tokens = get_tokens(lang, text)
+    tokens = fetch_tokens(lang, text)
     for token in tokens:
         results.append(
             {
@@ -457,7 +459,7 @@ async def debug_spacy(
                 "start": token.idx,
                 "tag": token.tag_,
                 "pos": token.pos_,
-                "word_type": get_token_type(token),
+                "word_type": fetch_token_type(token),
                 "morph": token.morph.get("Number"),
             }
         )
@@ -476,7 +478,7 @@ def get_categories(lang: LangType = "de"):
     response_model_exclude_none=True,
     dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
-async def check_v1_1(
+async def post_check_v1_1(
     request: Request,
     response: Response,
     user_request_in: RequestIn,
@@ -486,7 +488,7 @@ async def check_v1_1(
         version, request, response, user_request_in
     )
 
-    config = get_result_conf(rules, 1.1)
+    config = fetch_result_conf(rules, 1.1)
     if config == None and user_email:
         config = {}
 
@@ -507,7 +509,7 @@ async def check_v1_1(
     response_model_exclude_none=True,
     dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
-async def check_v2_0(
+async def post_check_v2_0(
     request: Request,
     response: Response,
     user_request_in: RequestIn,
@@ -531,7 +533,7 @@ async def check_v2_0(
         results=results,
         language=language,
         limit_reached=limit_reached,
-        config_changed=get_config_change(rules, user_request_in),
+        config_changed=fetch_config_change(rules, user_request_in),
         notifications=notifications,
         has_consented_to_mailing=has_consented_to_mailing,
     )
@@ -539,9 +541,9 @@ async def check_v2_0(
 
 # data exchange routes
 @app.post("/organization/rules")
-async def store_organization_rules(
+async def post_organization_rules(
     organization_rules: OrganizationConfRequest,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     redis.set(organization_rules.id, organization_rules.json())
 
@@ -554,7 +556,7 @@ async def store_organization_rules(
 )
 async def delete_organiztion_rules(
     organization_id: str,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     redis.delete(organization_id)
 
@@ -564,14 +566,14 @@ async def delete_organiztion_rules(
 )
 async def get_organization_rules(
     organization_id: str,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     return await fetch_organization_rules_from_redis(organization_id)
 
 
 @app.post("/user/rules")
-async def store_user_rules(
-    user_rules: UserConfRequest, username: str = Depends(get_current_username)
+async def post_user_rules(
+    user_rules: UserConfRequest, username: str = Depends(fetch_current_username)
 ):
     redis.set(user_rules.email, user_rules.json())
 
@@ -584,7 +586,7 @@ async def store_user_rules(
 )
 async def delete_user_rules(
     email: str,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     redis.delete(email)
 
@@ -592,7 +594,7 @@ async def delete_user_rules(
 @app.get("/user/rules", response_model=dict, responses={404: {"model": ErrorMessage}})
 async def get_user_rules(
     email: str,
-    username: str = Depends(get_current_username),
+    username: str = Depends(fetch_current_username),
 ):
     rules = await fetch_user_organization_rules(email)
 
@@ -756,7 +758,7 @@ async def fetch_organization_rules_for_request(
     return rules
 
 
-def get_user(request: Request):
+def fetch_user(request: Request):
     if "authorization" in request.headers and request.headers[
         "authorization"
     ].lower().startswith("bearer"):
@@ -800,7 +802,7 @@ def get_user(request: Request):
     return None
 
 
-def get_text(user_request_in):
+def fetch_text(user_request_in):
     text = user_request_in.text
     limit_reached = len(text) > settings.text_max_length
     if limit_reached:
@@ -832,7 +834,7 @@ async def check(
         response.status_code = status.HTTP_400_BAD_REQUEST
         return Result.factory("Version not supported: " + str(version))
 
-    user_email = get_user(request)
+    user_email = fetch_user(request)
     if version >= 2.0 and not user_email:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -840,7 +842,7 @@ async def check(
 
     rules = await fetch_rules_for_request(user_request_in, user_email)
 
-    text, lang, limit_reached = get_text(user_request_in)
+    text, lang, limit_reached = fetch_text(user_request_in)
 
     if lang == None:
         response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -857,7 +859,7 @@ async def check(
     return results, language, limit_reached, rules, user_email
 
 
-def get_config_change(
+def fetch_config_change(
     rules: dict,
     user_request_in: Optional[RequestIn] = None,
 ):
@@ -877,7 +879,7 @@ def get_config_change(
     return None
 
 
-def get_result_conf(
+def fetch_result_conf(
     rules: dict,
     version: float,
 ):
@@ -916,7 +918,7 @@ def get_result_conf(
     )
 
 
-def get_alternatives(match):
+def fetch_alternatives(match):
     alternatives = []
     if "replacements" in match:
         for replacement in match["replacements"]:
@@ -985,7 +987,7 @@ def languagetool_matches(
         ):
             continue
 
-        alternatives = get_alternatives(match)
+        alternatives = fetch_alternatives(match)
 
         label = match["shortMessage"]
         if label == "":
@@ -1082,19 +1084,19 @@ async def languagetool_rules(version: float, config: Config, lang: Language, tex
     return list_results
 
 
-def get_tokens(lang: Language, text: str):
+def fetch_tokens(lang: Language, text: str):
     # apply SpaCy pre-built model
     return model[lang.lang](text.rstrip().replace("\n", " "))
 
 
-def get_false_positive_matcher(tokens):
+def fetch_false_positive_matcher(tokens):
     # create false positives list
-    phrase_matches_false = get_matches(tokens, list_false_column)
+    phrase_matches_false = fetch_matches(tokens, list_false_column)
     word_matches_false = false_pattern_match(tokens)
     return list(set(phrase_matches_false + word_matches_false))
 
 
-def get_matches(tokens, phrases):
+def fetch_matches(tokens, phrases):
     # Phrase matcher part to handle False positives with two words and special symbols
     matcher = PhraseMatcher(model[lang.lang].vocab, attr="LOWER")
 
@@ -1107,7 +1109,7 @@ def get_matches(tokens, phrases):
 async def language_rules(
     version: float, config: Config, rules: dict, lang: Language, text: str
 ):
-    tokens = get_tokens(lang, text)
+    tokens = fetch_tokens(lang, text)
 
     list_results = []
     if is_sub_category_enabled(config, "orthography"):
@@ -1181,15 +1183,15 @@ async def language_rules(
 
 
 # Function for all German rules
-def get_lemma_lower_cased(token):
+def fetch_lemma_lower_cased(token):
     token_word = token.lemma_
 
     return token_word.lower()
 
 
-def get_lemma_non_noun_lower_cased(token, lang):
+def fetch_lemma_non_noun_lower_cased(token, lang):
     if not check_token_type(token, lang, "s"):
-        return get_lemma_lower_cased(token)
+        return fetch_lemma_lower_cased(token)
 
     return token.lemma_
 
@@ -1373,7 +1375,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
     gendered_words_alternatives_en = defaultdict(list)
     inclusive_sentences_alternatives_en = []
     sentences_alternatives_en = defaultdict(list)
-    matches_false = get_false_positive_matcher(tokens)
+    matches_false = fetch_false_positive_matcher(tokens)
 
     if lang.locale == "en-GB":
         words_alternatives_en["od"] = open_disc_words_alternatives_GB
@@ -1575,7 +1577,7 @@ def ing_ify_alternatives(token, alternatives):
 """Function to change adjectives to -en form in alternatives"""
 
 
-def get_token_type(token, token_type=None, single_word=None):
+def fetch_token_type(token, token_type=None, single_word=None):
     if token.pos_ == "VERB":
         return "v"
 
@@ -1616,7 +1618,7 @@ def check_token_type(token, lang, token_type=None, single_word=None):
     if token_type == None:
         return True
 
-    return get_token_type(token, token_type, single_word) in token_type.split(",")
+    return fetch_token_type(token, token_type, single_word) in token_type.split(",")
 
 
 def add_declension(lang, text, ending):
@@ -1637,7 +1639,7 @@ def alternative_declension(text, token_type, ending, lang, alternative):
     if ResultOut.isInspirationAlternative(text, alternative):
         return alternative
 
-    tokens = get_tokens(lang, alternative)
+    tokens = fetch_tokens(lang, alternative)
 
     if lang.lang == "en":
         alternative_token_types = ["v"]
@@ -1649,7 +1651,9 @@ def alternative_declension(text, token_type, ending, lang, alternative):
     for token in reversed(tokens):
         text = token.text
         if previous == False:
-            alternative_token_type = get_token_type(token, token_type, len(tokens) == 1)
+            alternative_token_type = fetch_token_type(
+                token, token_type, len(tokens) == 1
+            )
 
             if alternative_token_type in alternative_token_types:
                 previous = True
@@ -1665,7 +1669,7 @@ def alternative_declension(text, token_type, ending, lang, alternative):
 
 def alternatives_declension(token, lang, alternatives):
     endings = False
-    token_type = get_token_type(token)
+    token_type = fetch_token_type(token)
 
     if lang.lang == "en" and token_type == "v":
         endings = ["s"]
@@ -1802,9 +1806,9 @@ def agentic_language_analysis_de(
             alternative_plur,
             subcategory,
         ) in words_alternatives_noun:
-            if get_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
+            if fetch_lemma_non_noun_lower_cased(
+                token, lang
+            ) == word and check_token_type(token, lang, word_type, True):
                 token_morph_number = token.morph.get("Number")
                 if is_number_list_empty(token_morph_number, token, full_text):
                     continue
@@ -1847,9 +1851,9 @@ def ub_words_phrase_matcher_de(
 
     for token in tokens:
         for word, word_type, alternative, subcategory in words_alternatives:
-            if get_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
+            if fetch_lemma_non_noun_lower_cased(
+                token, lang
+            ) == word and check_token_type(token, lang, word_type, True):
                 alternative = alternatives_declension(token, lang, alternative)
 
                 list_tokens.append(
@@ -1867,7 +1871,7 @@ def ub_words_phrase_matcher_de(
                     )
                 )
 
-    matches = get_matches(tokens, list(df_sentence["Lemma"]))
+    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:
         for sentence, alternative, subcategory in sentences_alternatives:
             span = tokens[start:end]
@@ -1895,7 +1899,7 @@ def ignore_binary_inclusive_gendered_denom_analysis_de(
     tokens,
     false_positives,
 ):
-    matches = get_matches(tokens, false_positives)
+    matches = fetch_matches(tokens, false_positives)
     if matches.__len__() > 0:
         old_start = 0
         rest_text = []
@@ -2138,7 +2142,7 @@ def style_word_analysis_de(
                     )
                 )
 
-    matches = get_matches(tokens, terms)
+    matches = fetch_matches(tokens, terms)
     for match_id, start, end in matches:
         for sentence, alternative, subcategory in style_sentences_alternatives:
             span = tokens[start:end]
@@ -2183,9 +2187,9 @@ def word_noun_de(
             alternative_plur,
             subcategory,
         ) in bias_words_alternatives_noun:
-            if get_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
+            if fetch_lemma_non_noun_lower_cased(
+                token, lang
+            ) == word and check_token_type(token, lang, word_type, True):
                 token_morph_number = token.morph.get("Number")
                 if is_number_list_empty(token_morph_number, token, full_text):
                     continue
@@ -2235,9 +2239,9 @@ def rules_based_words_phrase_matcher_de(
 
     for token in tokens:
         for word, word_type, *data in words_alternatives:
-            if get_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
+            if fetch_lemma_non_noun_lower_cased(
+                token, lang
+            ) == word and check_token_type(token, lang, word_type, True):
                 if isinstance(data, list):
                     if len(data) >= 1:
                         alternative = alternatives_declension(token, lang, data[0])
@@ -2262,7 +2266,7 @@ def rules_based_words_phrase_matcher_de(
     if isinstance(df_sentence, pd.DataFrame):
         alternative = None
         subcategory = fallback_subcategory
-        matches = get_matches(tokens, list(df_sentence["Lemma"]))
+        matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
         for match_id, start, end in matches:
             span = tokens[start:end]
             if sentences_alternatives == None:
@@ -2277,7 +2281,7 @@ def rules_based_words_phrase_matcher_de(
                         subcategory,
                         span.start_char,
                         span.end_char,
-                        [],
+                        alternative,
                     )
                 )
             else:
@@ -2410,7 +2414,7 @@ def rules_based_words_phrase_matcher_en(
     for token in tokens:
         for word, word_type, alternative, subcategory in words_alternatives:
             if (
-                get_lemma_lower_cased(token) == word
+                fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
                 and is_false_positive_match(matches_false, tokens, token) == False
             ):
@@ -2432,7 +2436,7 @@ def rules_based_words_phrase_matcher_en(
                     )
                 )
 
-    matches = get_matches(tokens, list(df_sentence["Lemma"]))
+    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:
         for sentence, alternative, subcategory in sentences_alternatives:
             span = tokens[start:end]
@@ -2509,7 +2513,7 @@ def literal_match(
 ):
     list_tokens = []
 
-    matches = get_matches(tokens, list(df_term["Lemma"]))
+    matches = fetch_matches(tokens, list(df_term["Lemma"]))
     for match_id, start, end in matches:
         for (
             term,
@@ -2582,7 +2586,7 @@ def gendered_en(
             second_subcategory,
         ) in gendered_words_alternatives:
             if (
-                get_lemma_lower_cased(token) == word
+                fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
                 and is_false_positive_match(matches_false, tokens, token) == False
             ):
@@ -2638,7 +2642,7 @@ def rules_based_words_phrase_matcher_no_alt_en(
     for token in tokens:
         for word, word_type, subcategory in inclusive_words_alternatives_en:
             if (
-                get_lemma_lower_cased(token) == word
+                fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
                 and is_false_positive_match(matches_false, tokens, token) == False
             ):
@@ -2657,7 +2661,7 @@ def rules_based_words_phrase_matcher_no_alt_en(
                     )
                 )
 
-    matches = get_matches(tokens, list(df_sentence["Lemma"]))
+    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:
         for sentence, subcategory in inclusive_sentences_alternatives_en:
             span = tokens[start:end]

--- a/app/main.py
+++ b/app/main.py
@@ -1492,7 +1492,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         )
 
     if is_sub_category_enabled(config, "inclusive"):
-        list_full += rules_based_words_phrase_matcher_no_alt_en(
+        list_full += rules_based_words_phrase_matcher_en(
             version,
             config,
             lang,
@@ -2325,11 +2325,10 @@ def rules_based_words_phrase_matcher_de(
 
 # matcher to false positives
 def is_false_positive_match(list_false_positive, tokens, token):
-    if list_false_positive.__len__() > 0:
-        for match_id, start, end in list_false_positive:
-            span_false = tokens[start:end]
-            if token.idx in range(span_false.start_char, span_false.end_char):
-                return True
+    for match_id, start, end in list_false_positive:
+        span_false = tokens[start:end]
+        if token.idx in range(span_false.start_char, span_false.end_char):
+            return True
 
     return False
 
@@ -2421,16 +2420,21 @@ def rules_based_words_phrase_matcher_en(
     category,
 ):
     list_tokens = []
+    alternative = None
 
     for token in tokens:
-        for word, word_type, alternative, subcategory in words_alternatives:
+        for word, word_type, *data in words_alternatives:
             if (
                 fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
                 and is_false_positive_match(matches_false, tokens, token) == False
             ):
-                alternative = ing_ify_alternatives(token, alternative)
-                alternative = alternatives_declension(token, lang, alternative)
+                if len(data) > 1:
+                    alternative = ing_ify_alternatives(token, data[0])
+                    alternative = alternatives_declension(token, lang, alternative)
+                    subcategory = data[1]
+                else:
+                    subcategory = data[0]
 
                 list_tokens.append(
                     ResultOut.factory(
@@ -2620,57 +2624,6 @@ def gendered_en(
                     )
 
     return list_tokens
-
-
-# english function, no alternatives
-
-
-def rules_based_words_phrase_matcher_no_alt_en(
-    version: float,
-    config: Config,
-    lang,
-    full_text,
-    tokens,
-    matches_false,
-    words_alternatives,
-    sentences_alternatives,
-    df_sentence,
-    category,
-):
-    list_tokens = []
-
-    for token in tokens:
-        for word, word_type, subcategory in words_alternatives:
-            if (
-                fetch_lemma_lower_cased(token) == word
-                and check_token_type(token, lang, word_type, True)
-                and is_false_positive_match(matches_false, tokens, token) == False
-            ):
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        token.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        token.idx,
-                        token.idx + len(token.text),
-                        [],
-                    )
-                )
-
-    return list_tokens + sentences_matcher(
-        version,
-        config,
-        lang,
-        full_text,
-        tokens,
-        sentences_alternatives,
-        list(df_sentence["Lemma"]),
-        category,
-    )
 
 
 # want to server to run app.py in the folder app as main app, port=8000 is defaut port for the fast api

--- a/app/main.py
+++ b/app/main.py
@@ -307,7 +307,9 @@ def get_swagger_documentation(
 
 
 @app.get("/openapi.json", include_in_schema=False)
-def get_openapi(username: str = Depends(fetch_current_username)):  # pragma: no cover
+def get_openapi_json(
+    username: str = Depends(fetch_current_username),
+):  # pragma: no cover
     return get_openapi(title=app.title, version=app.version, routes=app.routes)
 
 
@@ -1416,7 +1418,7 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
         sentences_alternatives_en["style"] = style_sentences_alternatives_US
         sentences_alternatives_en["bias"] = bias_sentences_alternatives_US
 
-    list_full += homonyms_english(
+    list_full += homonyms_en(
         version,
         config,
         lang,
@@ -1639,12 +1641,14 @@ def alternative_declension(text, token_type, ending, lang, alternative):
     if ResultOut.isInspirationAlternative(text, alternative):
         return alternative
 
-    tokens = fetch_tokens(lang, alternative)
-
     if lang.lang == "en":
         alternative_token_types = ["v"]
     elif lang.lang == "de":
         alternative_token_types = ["v", "a"]
+    else:
+        return alternative
+
+    tokens = fetch_tokens(lang, alternative)
 
     new_alternative = ""
     previous = False
@@ -1793,7 +1797,7 @@ def agentic_language_analysis_de(
     lang,
     full_text,
     tokens,
-    words_alternatives_noun,
+    words_alternatives,
     category,
 ):
     list_tokens = []
@@ -1805,10 +1809,10 @@ def agentic_language_analysis_de(
             alternative_sing,
             alternative_plur,
             subcategory,
-        ) in words_alternatives_noun:
-            if fetch_lemma_non_noun_lower_cased(
-                token, lang
-            ) == word and check_token_type(token, lang, word_type, True):
+        ) in words_alternatives:
+            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
+                token, lang, word_type, True
+            ):
                 token_morph_number = token.morph.get("Number")
                 if is_number_list_empty(token_morph_number, token, full_text):
                     continue
@@ -1975,7 +1979,7 @@ def gendered_denom_analysis_de(
     lang,
     full_text,
     tokens,
-    gender_words_alternatives,
+    words_alternatives,
     false_positives,
 ):
     category = "gendered"
@@ -1995,7 +1999,7 @@ def gendered_denom_analysis_de(
             alternatives_plur,
             alternatives_all,
             subcategory,
-        ) in gender_words_alternatives:
+        ) in words_alternatives:
             if tokens[i].lemma_ == word and check_token_type(
                 tokens[i], lang, word_type, True
             ):
@@ -2105,9 +2109,9 @@ def style_word_analysis_de(
     lang,
     full_text,
     tokens,
-    terms,
-    style_words_alternatives,
-    style_sentences_alternatives,
+    df_sentences,
+    words_alternatives,
+    sentences_alternatives,
     false_positives,
 ):
     category = "style"
@@ -2123,7 +2127,7 @@ def style_word_analysis_de(
         if token.lemma_ == "aber" and is_conjunction(full_text, token.idx):
             continue
 
-        for word, word_type, alternative, subcategory in style_words_alternatives:
+        for word, word_type, alternative, subcategory in words_alternatives:
             if token.lemma_ == word and check_token_type(token, lang, word_type, True):
                 alternative = alternatives_declension(token, lang, alternative)
 
@@ -2142,9 +2146,9 @@ def style_word_analysis_de(
                     )
                 )
 
-    matches = fetch_matches(tokens, terms)
+    matches = fetch_matches(tokens, df_sentences)
     for match_id, start, end in matches:
-        for sentence, alternative, subcategory in style_sentences_alternatives:
+        for sentence, alternative, subcategory in sentences_alternatives:
             span = tokens[start:end]
             if span.text.lower() == sentence.lower():
                 list_tokens.append(
@@ -2169,12 +2173,12 @@ def style_word_analysis_de(
 
 
 def word_noun_de(
-    version: version,
+    version: float,
     config: Config,
     lang,
     full_text,
     tokens,
-    bias_words_alternatives_noun,
+    words_alternatives,
     category,
 ):
     list_tokens = []
@@ -2186,10 +2190,10 @@ def word_noun_de(
             alternative_sing,
             alternative_plur,
             subcategory,
-        ) in bias_words_alternatives_noun:
-            if fetch_lemma_non_noun_lower_cased(
-                token, lang
-            ) == word and check_token_type(token, lang, word_type, True):
+        ) in words_alternatives:
+            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
+                token, lang, word_type, True
+            ):
                 token_morph_number = token.morph.get("Number")
                 if is_number_list_empty(token_morph_number, token, full_text):
                     continue
@@ -2460,19 +2464,19 @@ def rules_based_words_phrase_matcher_en(
 
 
 # english function to handle homonyms
-def homonyms_english(
+def homonyms_en(
     version: float,
     config: Config,
     lang,
     full_text,
     tokens,
     matches_false,
-    homonyms_words,
+    words_alternatives,
 ):
     list_tokens = []
 
     for token in tokens:
-        for word, word_type, category, subcategory, alternative in homonyms_words:
+        for word, word_type, category, subcategory, alternative in words_alternatives:
             if not is_sub_category_enabled(config, subcategory):
                 continue
 
@@ -2508,12 +2512,12 @@ def literal_match(
     lang,
     full_text,
     tokens,
-    df_term,
+    df_sentence,
     term_list,
 ):
     list_tokens = []
 
-    matches = fetch_matches(tokens, list(df_term["Lemma"]))
+    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:
         for (
             term,
@@ -2571,7 +2575,7 @@ def gendered_en(
     full_text,
     tokens,
     matches_false,
-    gendered_words_alternatives,
+    words_alternatives,
     category,
 ):
     list_tokens = []
@@ -2584,7 +2588,7 @@ def gendered_en(
             alternative_plur,
             subcategory,
             second_subcategory,
-        ) in gendered_words_alternatives:
+        ) in words_alternatives:
             if (
                 fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
@@ -2632,15 +2636,15 @@ def rules_based_words_phrase_matcher_no_alt_en(
     full_text,
     tokens,
     matches_false,
-    inclusive_words_alternatives_en,
-    inclusive_sentences_alternatives_en,
+    words_alternatives,
+    sentences_alternatives,
     df_sentence,
     category,
 ):
     list_tokens = []
 
     for token in tokens:
-        for word, word_type, subcategory in inclusive_words_alternatives_en:
+        for word, word_type, subcategory in words_alternatives:
             if (
                 fetch_lemma_lower_cased(token) == word
                 and check_token_type(token, lang, word_type, True)
@@ -2663,7 +2667,7 @@ def rules_based_words_phrase_matcher_no_alt_en(
 
     matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:
-        for sentence, subcategory in inclusive_sentences_alternatives_en:
+        for sentence, subcategory in sentences_alternatives:
             span = tokens[start:end]
             if span.text.lower() == sentence.lower():
                 list_tokens.append(

--- a/app/main.py
+++ b/app/main.py
@@ -126,14 +126,14 @@ async def handle_command_witty(
 
     try:
         user = await client.users_info(user=body["user_id"])
-        rules = await fetch_user_rules(
+        rules = await fetch_rules_for_request(
             user_request_in, user.data["user"]["profile"]["email"]
         )
     except KeyError:
         pass
 
     if rules == {} and settings.slack_organization_id:
-        rules = await fetch_organization_rules(
+        rules = await fetch_organization_rules_for_request(
             user_request_in, settings.slack_organization_id
         )
 
@@ -375,7 +375,7 @@ async def auth_debug(request: Request, user_request_in: RequestIn):  # pragma: n
     if not user_email:
         return user_email
 
-    rules = await fetch_user_rules(user_request_in, user_email)
+    rules = await fetch_rules_for_request(user_request_in, user_email)
 
     if "authorization" in request.headers and request.headers[
         "authorization"
@@ -402,7 +402,7 @@ async def auth_1_1(request: Request, response: Response):
     if not user_email:
         return None
 
-    rules = await fetch_user_rules(RequestIn(text=""), user_email)
+    rules = await fetch_rules_for_request(RequestIn(text=""), user_email)
     config = get_result_conf(rules, 1.1)
     if config == None and user_email:
         config = {}
@@ -423,7 +423,7 @@ async def auth_2_0(request: Request, response: Response):
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
-    rules = await fetch_user_rules(RequestIn(text=""), user_email)
+    rules = await fetch_rules_for_request(RequestIn(text=""), user_email)
     if rules == {}:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -543,54 +543,6 @@ async def check_v2_0(
 
 
 # data exchange routes
-
-
-# BC
-@app.post("/store_rules")
-async def store_rules(
-    organization_rules: ConfRequest1_1,
-    username: str = Depends(get_current_username),
-):
-    rules = redis.get(organization_rules.id)
-
-    # Set a value
-    redis.set(organization_rules.id, organization_rules.json())
-    for user in organization_rules.users:
-        redis.set(str(user), organization_rules.id)
-
-    if rules:
-        rules = json.loads(rules)
-        for user in rules["users"]:
-            if user not in organization_rules.users:
-                redis.delete(str(user))
-
-    return organization_rules
-
-
-# BC
-@app.delete(
-    "/delete_rules",
-    status_code=status.HTTP_204_NO_CONTENT,
-    responses={404: {"model": ErrorMessage}},
-)
-async def delete_rules(
-    organization_id: str,
-    username: str = Depends(get_current_username),
-):
-    rules = redis.get(organization_id)
-
-    if not rules:
-        return JSONResponse(
-            status_code=404, content={"message": "User rules not found"}
-        )
-
-    rules = json.loads(rules)
-    for user in rules["users"]:
-        redis.delete(str(user))
-
-    redis.delete(organization_id)
-
-
 @app.post("/organization/rules")
 async def store_organization_rules(
     organization_rules: OrganizationConfRequest,
@@ -604,19 +556,11 @@ async def store_organization_rules(
 @app.delete(
     "/organization/rules",
     status_code=status.HTTP_204_NO_CONTENT,
-    responses={404: {"model": ErrorMessage}},
 )
 async def delete_organiztion_rules(
     organization_id: str,
     username: str = Depends(get_current_username),
 ):
-    rules = redis.get(organization_id)
-
-    if not rules:
-        return JSONResponse(
-            status_code=404, content={"message": "Organization rules not found"}
-        )
-
     redis.delete(organization_id)
 
 
@@ -627,14 +571,7 @@ async def get_organization_rules(
     organization_id: str,
     username: str = Depends(get_current_username),
 ):
-    rules = redis.get(organization_id)
-
-    if not rules:
-        return JSONResponse(
-            status_code=404, content={"message": "User rules not found"}
-        )
-
-    return json.loads(rules)
+    return await fetch_organization_rules_from_redis(organization_id)
 
 
 @app.post("/user/rules")
@@ -649,19 +586,11 @@ async def store_user_rules(
 @app.delete(
     "/user/rules",
     status_code=status.HTTP_204_NO_CONTENT,
-    responses={404: {"model": ErrorMessage}},
 )
 async def delete_user_rules(
     email: str,
     username: str = Depends(get_current_username),
 ):
-    rules = redis.get(email)
-
-    if not rules:
-        return JSONResponse(
-            status_code=404, content={"message": "User rules not found"}
-        )
-
     redis.delete(email)
 
 
@@ -670,7 +599,7 @@ async def get_user_rules(
     email: str,
     username: str = Depends(get_current_username),
 ):
-    rules = await fetch_user_rules_from_redis(email)
+    rules = await fetch_user_organization_rules(email)
 
     if not rules or type(rules) is not dict:
         return JSONResponse(
@@ -681,52 +610,43 @@ async def get_user_rules(
 
 
 # Functions
-async def fetch_user_rules_from_redis(email: str):
-    rules = redis.get(email)
-
+async def fetch_organization_rules_from_redis(
+    organization_id: str,
+):
+    rules = redis.get(organization_id)
     if not rules:
-        return None
+        raise HTTPException(status_code=404, detail="Organization rules not found")
 
-    format_1_1 = False
+    return json.loads(rules)
 
+
+async def fetch_user_rules_from_redis(
+    email: str,
+):
+    rules = redis.get(email)
+    if not rules:
+        raise HTTPException(status_code=404, detail="User rules not found")
+
+    return json.loads(rules)
+
+
+async def fetch_user_organization_rules(email: str):
     try:
-        rules = json.loads(rules)
-    except ValueError as e:
-        # handle old format
-        format_1_1 = True
-
-        rules = {
-            "id": email,
-            "name": email,
-            "email": email,
-            "organization_id": rules,
-            "config": {},
-            "term_replacements": {},
-            "false_positives": [],
-            "domains": {},
-            "organization_domains": {},
-            "notifications": None,
-        }
+        rules = await fetch_user_rules_from_redis(email)
+    except HTTPException:
+        return None
 
     rules["plan"] = "witty_free"
     rules["organization_name"] = None
 
     if "organization_id" in rules and rules["organization_id"] != None:
-        organization_rules = redis.get(rules["organization_id"])
-
-        if organization_rules:
-            organization_rules = json.loads(organization_rules)
+        try:
+            organization_rules = await fetch_organization_rules_from_redis(
+                rules["organization_id"]
+            )
 
             rules["plan"] = organization_rules["plan"]
             rules["organization_name"] = organization_rules["name"]
-
-            if format_1_1:
-                term_replacements = {}
-                for rule in organization_rules["term_replacements"]:
-                    term = rule["term"]
-                    del rule["term"]
-                    term_replacements[term] = rule
-                organization_rules["term_replacements"] = term_replacements
 
             if "config_hash" in organization_rules:
                 rules["organization_config_hash"] = organization_rules["config_hash"]
@@ -745,19 +665,10 @@ async def fetch_user_rules_from_redis(email: str):
             rules["organization_false_positives"] = organization_rules[
                 "false_positives"
             ]
+        except HTTPException:
+            pass
     else:
         rules["organization_id"] = None
-
-    return rules
-
-
-async def fetch_organization_rules_from_redis(organization_id: str):
-    rules = redis.get(organization_id)
-
-    if not rules:
-        return None
-
-    rules = json.loads(rules)
 
     return rules
 
@@ -805,13 +716,13 @@ def apply_rules(user_request_in: RequestIn, configs: dict, plan: str):
     user_request_in.config.__setattr__("disabled_categories", disabled_categories)
 
 
-async def fetch_user_rules(user_request_in: RequestIn, user_email=Optional[str]):
+async def fetch_rules_for_request(user_request_in: RequestIn, user_email=Optional[str]):
     user_request_in.config.__setattr__("store_context", True)
 
     if not user_email:
         return {}
 
-    rules = await fetch_user_rules_from_redis(user_email)
+    rules = await fetch_user_organization_rules(user_email)
     if not rules or type(rules) is not dict:
         return {}
 
@@ -828,7 +739,7 @@ async def fetch_user_rules(user_request_in: RequestIn, user_email=Optional[str])
     return rules
 
 
-async def fetch_organization_rules(
+async def fetch_organization_rules_for_request(
     user_request_in: RequestIn, organization_id=Optional[str]
 ):
     user_request_in.config.__setattr__("store_context", True)
@@ -836,8 +747,9 @@ async def fetch_organization_rules(
     if not organization_id:
         return {}
 
-    rules = await fetch_organization_rules_from_redis(organization_id)
-    if not rules or type(rules) is not dict:
+    try:
+        rules = await fetch_organization_rules_from_redis(organization_id)
+    except HTTPException:
         return {}
 
     for config in rules["configs"]:
@@ -931,7 +843,7 @@ async def check(
             status_code=status.HTTP_403_FORBIDDEN,
         )
 
-    rules = await fetch_user_rules(user_request_in, user_email)
+    rules = await fetch_rules_for_request(user_request_in, user_email)
 
     text, lang, limit_reached = get_text(user_request_in)
 
@@ -1851,7 +1763,8 @@ def plural_or_singular_en(
 ):
     if token_morph_number[0] == "Sing":
         return alternative_sing, subcategory
-    elif token_morph_number[0] == "Plur":
+
+    if token_morph_number[0] == "Plur":
         return [
             item for item in alternative_plur if item != token.text.lower()
         ], second_subcategory
@@ -1864,7 +1777,8 @@ def plural_or_singular_alternatives_de(
 ):
     if token_morph_number[0] == "Sing":
         return alternative_sing
-    elif token_morph_number[0] == "Plur":
+
+    if token_morph_number[0] == "Plur":
         return alternative_plur
 
     return None
@@ -2500,27 +2414,28 @@ def rules_based_words_phrase_matcher_en(
 
     for token in tokens:
         for word, word_type, alternative, subcategory in words_alternatives:
-            if get_lemma_lower_cased(token) == word and check_token_type(
-                token, lang, word_type, True
+            if (
+                get_lemma_lower_cased(token) == word
+                and check_token_type(token, lang, word_type, True)
+                and is_false_positive_match(matches_false, tokens, token) == False
             ):
-                if is_false_positive_match(matches_false, tokens, token) == False:
-                    alternative = ing_ify_alternatives(token, alternative)
-                    alternative = alternatives_declension(token, lang, alternative)
+                alternative = ing_ify_alternatives(token, alternative)
+                alternative = alternatives_declension(token, lang, alternative)
 
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            alternative,
-                        )
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        token.text,
+                        full_text,
+                        category,
+                        subcategory,
+                        token.idx,
+                        token.idx + len(token.text),
+                        alternative,
                     )
+                )
 
     matches = get_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:
@@ -2562,24 +2477,27 @@ def homonyms_english(
             if not is_sub_category_enabled(config, subcategory):
                 continue
 
-            if token.lemma_ == word and check_token_type(token, lang, word_type, True):
-                if is_false_positive_match(matches_false, tokens, token) == False:
-                    alternative = ing_ify_alternatives(token, alternative)
+            if (
+                token.lemma_ == word
+                and check_token_type(token, lang, word_type, True)
+                and is_false_positive_match(matches_false, tokens, token) == False
+            ):
+                alternative = ing_ify_alternatives(token, alternative)
 
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            alternative,
-                        )
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        token.text,
+                        full_text,
+                        category,
+                        subcategory,
+                        token.idx,
+                        token.idx + len(token.text),
+                        alternative,
                     )
+                )
 
     return list_tokens
 
@@ -2668,38 +2586,39 @@ def gendered_en(
             subcategory,
             second_subcategory,
         ) in gendered_words_alternatives:
-            if get_lemma_lower_cased(token) == word and check_token_type(
-                token, lang, word_type, True
+            if (
+                get_lemma_lower_cased(token) == word
+                and check_token_type(token, lang, word_type, True)
+                and is_false_positive_match(matches_false, tokens, token) == False
             ):
-                if is_false_positive_match(matches_false, tokens, token) == False:
-                    token_morph_number = token.morph.get("Number")
-                    if is_number_list_empty(token_morph_number, token, full_text):
-                        continue
+                token_morph_number = token.morph.get("Number")
+                if is_number_list_empty(token_morph_number, token, full_text):
+                    continue
 
-                    alternative, subcategory = plural_or_singular_en(
-                        token,
-                        token_morph_number,
-                        alternative_sing,
-                        alternative_plur,
-                        subcategory,
-                        second_subcategory,
-                    )
+                alternative, subcategory = plural_or_singular_en(
+                    token,
+                    token_morph_number,
+                    alternative_sing,
+                    alternative_plur,
+                    subcategory,
+                    second_subcategory,
+                )
 
-                    if alternative != None:
-                        list_tokens.append(
-                            ResultOut.factory(
-                                version,
-                                config,
-                                lang,
-                                token.text,
-                                full_text,
-                                category,
-                                subcategory,
-                                token.idx,
-                                token.idx + len(token.text),
-                                alternative,
-                            )
+                if alternative != None:
+                    list_tokens.append(
+                        ResultOut.factory(
+                            version,
+                            config,
+                            lang,
+                            token.text,
+                            full_text,
+                            category,
+                            subcategory,
+                            token.idx,
+                            token.idx + len(token.text),
+                            alternative,
                         )
+                    )
 
     return list_tokens
 
@@ -2723,24 +2642,25 @@ def rules_based_words_phrase_matcher_no_alt_en(
 
     for token in tokens:
         for word, word_type, subcategory in inclusive_words_alternatives_en:
-            if get_lemma_lower_cased(token) == word and check_token_type(
-                token, lang, word_type, True
+            if (
+                get_lemma_lower_cased(token) == word
+                and check_token_type(token, lang, word_type, True)
+                and is_false_positive_match(matches_false, tokens, token) == False
             ):
-                if is_false_positive_match(matches_false, tokens, token) == False:
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            [],
-                        )
+                list_tokens.append(
+                    ResultOut.factory(
+                        version,
+                        config,
+                        lang,
+                        token.text,
+                        full_text,
+                        category,
+                        subcategory,
+                        token.idx,
+                        token.idx + len(token.text),
+                        [],
                     )
+                )
 
     matches = get_matches(tokens, list(df_sentence["Lemma"]))
     for match_id, start, end in matches:

--- a/app/main.py
+++ b/app/main.py
@@ -1184,18 +1184,13 @@ async def language_rules(
     return list_results
 
 
-# Function for all German rules
-def fetch_lemma_lower_cased(token):
+def fetch_lemma_lower_cased(token, lang):
     token_word = token.lemma_
 
-    return token_word.lower()
+    if lang.lang == "en" or not check_token_type(token, lang, "s"):
+        return token_word.lower()
 
-
-def fetch_lemma_non_noun_lower_cased(token, lang):
-    if not check_token_type(token, lang, "s"):
-        return fetch_lemma_lower_cased(token)
-
-    return token.lemma_
+    return token_word
 
 
 def check_category_importance(config: Config, subcategory: str):
@@ -1302,7 +1297,7 @@ def german_rules(version: float, config: Config, lang: Language, tokens, text: s
             bias_sentences_data,
             rules["de-DE"]["df_ub_sentences"],
             "unconscious_bias",
-        ) + agentic_language_analysis_de(
+        ) + word_noun(
             version,
             config,
             lang,
@@ -1480,15 +1475,15 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
                 rules[lang.locale]["df_gendered_sentence"],
                 "gendered",
             )
-        list_full += gendered_en(
+        list_full += word_noun(
             version,
             config,
             lang,
             text,
             tokens,
-            matches_false,
             gendered_words_data_en["gendered"],
             "gendered",
+            matches_false,
         )
 
     if is_sub_category_enabled(config, "inclusive"):
@@ -1531,15 +1526,15 @@ def english_rules(version: float, config: Config, lang: Language, tokens, text: 
             sentences_data_en["bias"],
             rules[lang.locale]["df_ub_sentence"],
             "unconscious_bias",
-        ) + gendered_en(
+        ) + word_noun(
             version,
             config,
             lang,
             text,
             tokens,
-            matches_false,
             gendered_words_data_en["bias"],
             "unconscious_bias",
+            matches_false,
         )
     return list_full
 
@@ -1850,55 +1845,6 @@ def sentences_matcher(
 # this function agentic language & related false positives
 
 
-def agentic_language_analysis_de(
-    version: float,
-    config: Config,
-    lang,
-    full_text,
-    tokens,
-    words_data,
-    category,
-):
-    list_tokens = []
-
-    for token in tokens:
-        for (
-            word,
-            word_type,
-            alternative_sing,
-            alternative_plur,
-            subcategory,
-        ) in words_data:
-            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
-            ):
-                token_morph_number = token.morph.get("Number")
-                if is_number_list_empty(token_morph_number, token, full_text):
-                    continue
-
-                alternative = plural_or_singular_alternatives_de(
-                    token_morph_number, alternative_sing, alternative_plur
-                )
-
-                if alternative != None:
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            alternative,
-                        )
-                    )
-
-    return list_tokens
-
-
 def ub_words_phrase_matcher_de(
     version: float,
     config: Config,
@@ -1914,7 +1860,7 @@ def ub_words_phrase_matcher_de(
 
     for token in tokens:
         for word, word_type, alternative, subcategory in words_data:
-            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
+            if fetch_lemma_lower_cased(token, lang) == word and check_token_type(
                 token, lang, word_type, True
             ):
                 alternative = alternatives_declension(token, lang, alternative)
@@ -2206,10 +2152,7 @@ def style_word_analysis_de(
     )
 
 
-# German function to show plural and singular forms of alternatives for nouns
-
-
-def word_noun_de(
+def word_noun(
     version: float,
     config: Config,
     lang,
@@ -2217,6 +2160,7 @@ def word_noun_de(
     tokens,
     words_data,
     category,
+    matches_false=[],
 ):
     list_tokens = []
 
@@ -2227,17 +2171,30 @@ def word_noun_de(
             alternative_sing,
             alternative_plur,
             subcategory,
+            *data,
         ) in words_data:
-            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
-                token, lang, word_type, True
+            if (
+                fetch_lemma_lower_cased(token, lang) == word
+                and check_token_type(token, lang, word_type, True)
+                and is_false_positive_match(matches_false, tokens, token) == False
             ):
                 token_morph_number = token.morph.get("Number")
                 if is_number_list_empty(token_morph_number, token, full_text):
                     continue
 
-                alternative = plural_or_singular_alternatives_de(
-                    token_morph_number, alternative_sing, alternative_plur
-                )
+                if lang.lang == "de":
+                    alternative = plural_or_singular_alternatives_de(
+                        token_morph_number, alternative_sing, alternative_plur
+                    )
+                else:
+                    alternative, subcategory = plural_or_singular_en(
+                        token,
+                        token_morph_number,
+                        alternative_sing,
+                        alternative_plur,
+                        subcategory,
+                        data[0],
+                    )
 
                 if alternative != None:
                     list_tokens.append(
@@ -2280,7 +2237,7 @@ def rules_based_words_phrase_matcher_de(
 
     for token in tokens:
         for word, word_type, *data in words_data:
-            if fetch_lemma_non_noun_lower_cased(token, lang) == word and check_token_type(
+            if fetch_lemma_lower_cased(token, lang) == word and check_token_type(
                 token, lang, word_type, True
             ):
                 if isinstance(data, list):
@@ -2424,7 +2381,7 @@ def rules_based_words_phrase_matcher_en(
     for token in tokens:
         for word, word_type, *data in words_data:
             if (
-                fetch_lemma_lower_cased(token) == word
+                fetch_lemma_lower_cased(token, lang) == word
                 and check_token_type(token, lang, word_type, True)
                 and is_false_positive_match(matches_false, tokens, token) == False
             ):
@@ -2560,67 +2517,6 @@ def literal_match(
                         icon,
                     )
                 )
-
-    return list_tokens
-
-
-# english function to show plural and singular forms of alternatives for nouns
-
-
-def gendered_en(
-    version: float,
-    config: Config,
-    lang,
-    full_text,
-    tokens,
-    matches_false,
-    words_data,
-    category,
-):
-    list_tokens = []
-
-    for token in tokens:
-        for (
-            word,
-            word_type,
-            alternative_sing,
-            alternative_plur,
-            subcategory,
-            second_subcategory,
-        ) in words_data:
-            if (
-                fetch_lemma_lower_cased(token) == word
-                and check_token_type(token, lang, word_type, True)
-                and is_false_positive_match(matches_false, tokens, token) == False
-            ):
-                token_morph_number = token.morph.get("Number")
-                if is_number_list_empty(token_morph_number, token, full_text):
-                    continue
-
-                alternative, subcategory = plural_or_singular_en(
-                    token,
-                    token_morph_number,
-                    alternative_sing,
-                    alternative_plur,
-                    subcategory,
-                    second_subcategory,
-                )
-
-                if alternative != None:
-                    list_tokens.append(
-                        ResultOut.factory(
-                            version,
-                            config,
-                            lang,
-                            token.text,
-                            full_text,
-                            category,
-                            subcategory,
-                            token.idx,
-                            token.idx + len(token.text),
-                            alternative,
-                        )
-                    )
 
     return list_tokens
 

--- a/app/main.py
+++ b/app/main.py
@@ -1787,6 +1787,66 @@ def plural_or_singular_alternatives_de(
     return None
 
 
+def sentences_matcher(
+    version: float,
+    config: Config,
+    lang,
+    full_text,
+    tokens,
+    sentences_alternatives,
+    sentences_list,
+    category,
+    fallback_subcategory=None,
+):
+    list_tokens = []
+    alternative = None
+    subcategory = fallback_subcategory
+
+    matches = fetch_matches(tokens, sentences_list)
+    for match_id, start, end in matches:
+        span = tokens[start:end]
+        if sentences_alternatives == None:
+            list_tokens.append(
+                ResultOut.factory(
+                    version,
+                    config,
+                    lang,
+                    span.text,
+                    full_text,
+                    category,
+                    subcategory,
+                    span.start_char,
+                    span.end_char,
+                    alternative,
+                )
+            )
+        else:
+            for sentence, *data in sentences_alternatives:
+                if span.text.lower() == sentence.lower():
+                    if len(data) >= 2:
+                        alternative = data[0]
+                        subcategory = data[1]
+                    elif len(data) >= 1:
+                        alternative = data[0]
+
+                    list_tokens.append(
+                        ResultOut.factory(
+                            version,
+                            config,
+                            lang,
+                            span.text,
+                            full_text,
+                            category,
+                            subcategory,
+                            span.start_char,
+                            span.end_char,
+                            alternative,
+                        )
+                    )
+
+    return list_tokens
+
+
 """Function to handle dependecies of the adjectives."""
 # this function agentic language & related false positives
 
@@ -1875,27 +1935,16 @@ def ub_words_phrase_matcher_de(
                     )
                 )
 
-    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
-    for match_id, start, end in matches:
-        for sentence, alternative, subcategory in sentences_alternatives:
-            span = tokens[start:end]
-            if span.text.lower() == sentence.lower():
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start_char,
-                        span.end_char,
-                        alternative,
-                    )
-                )
-
-    return list_tokens
+    return list_tokens + sentences_matcher(
+        version,
+        config,
+        lang,
+        full_text,
+        tokens,
+        sentences_alternatives,
+        list(df_sentence["Lemma"]),
+        category,
+    )
 
 
 def ignore_binary_inclusive_gendered_denom_analysis_de(
@@ -2146,27 +2195,16 @@ def style_word_analysis_de(
                     )
                 )
 
-    matches = fetch_matches(tokens, df_sentences)
-    for match_id, start, end in matches:
-        for sentence, alternative, subcategory in sentences_alternatives:
-            span = tokens[start:end]
-            if span.text.lower() == sentence.lower():
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start_char,
-                        span.end_char,
-                        alternative,
-                    )
-                )
-
-    return list_tokens
+    return list_tokens + sentences_matcher(
+        version,
+        config,
+        lang,
+        full_text,
+        tokens,
+        sentences_alternatives,
+        df_sentences,
+        category,
+    )
 
 
 # German function to show plural and singular forms of alternatives for nouns
@@ -2268,48 +2306,17 @@ def rules_based_words_phrase_matcher_de(
                 )
 
     if isinstance(df_sentence, pd.DataFrame):
-        alternative = None
-        subcategory = fallback_subcategory
-        matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
-        for match_id, start, end in matches:
-            span = tokens[start:end]
-            if sentences_alternatives == None:
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start_char,
-                        span.end_char,
-                        alternative,
-                    )
-                )
-            else:
-                for sentence, *data in sentences_alternatives:
-                    if span.text.lower() == sentence.lower():
-                        if len(data) >= 1:
-                            alternative = data[0]
-                        if len(data) >= 2:
-                            subcategory = data[1]
-
-            list_tokens.append(
-                ResultOut.factory(
-                    version,
-                    config,
-                    lang,
-                    span.text,
-                    full_text,
-                    category,
-                    subcategory,
-                    span.start_char,
-                    span.end_char,
-                    alternative,
-                )
-            )
+        list_tokens += sentences_matcher(
+            version,
+            config,
+            lang,
+            full_text,
+            tokens,
+            sentences_alternatives,
+            list(df_sentence["Lemma"]),
+            category,
+            fallback_subcategory,
+        )
 
     return list_tokens
 
@@ -2440,27 +2447,16 @@ def rules_based_words_phrase_matcher_en(
                     )
                 )
 
-    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
-    for match_id, start, end in matches:
-        for sentence, alternative, subcategory in sentences_alternatives:
-            span = tokens[start:end]
-            if span.text.lower() == sentence.lower():
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start_char,
-                        span.end_char,
-                        alternative,
-                    )
-                )
-
-    return list_tokens
+    return list_tokens + sentences_matcher(
+        version,
+        config,
+        lang,
+        full_text,
+        tokens,
+        sentences_alternatives,
+        list(df_sentence["Lemma"]),
+        category,
+    )
 
 
 # english function to handle homonyms
@@ -2665,27 +2661,16 @@ def rules_based_words_phrase_matcher_no_alt_en(
                     )
                 )
 
-    matches = fetch_matches(tokens, list(df_sentence["Lemma"]))
-    for match_id, start, end in matches:
-        for sentence, subcategory in sentences_alternatives:
-            span = tokens[start:end]
-            if span.text.lower() == sentence.lower():
-                list_tokens.append(
-                    ResultOut.factory(
-                        version,
-                        config,
-                        lang,
-                        span.text,
-                        full_text,
-                        category,
-                        subcategory,
-                        span.start_char,
-                        span.end_char,
-                        [],
-                    )
-                )
-
-    return list_tokens
+    return list_tokens + sentences_matcher(
+        version,
+        config,
+        lang,
+        full_text,
+        tokens,
+        sentences_alternatives,
+        list(df_sentence["Lemma"]),
+        category,
+    )
 
 
 # want to server to run app.py in the folder app as main app, port=8000 is defaut port for the fast api

--- a/app/rules.py
+++ b/app/rules.py
@@ -70,9 +70,7 @@ rules["de-DE"]["terms_style"] = list(rules["de-DE"]["df_style_sentences"]["Lemma
 
 # list of "d_and_i_words word" sentences
 rules["de-DE"]["df_terms_d_and_i_words"] = list(
-    zip(
-        rules["de-DE"]["df_d_and_i_words_sentences"]["Lemma"],
-    )
+    rules["de-DE"]["df_d_and_i_words_sentences"]["Lemma"],
 )
 
 # list of "d_and_i_words word" sentences

--- a/app/rules.py
+++ b/app/rules.py
@@ -112,7 +112,7 @@ rules["de-DE"]["exceptions"] = [
 # df gender
 df_gender = rules["de-DE"]["df_gender_ct"]
 # gender: words + singular alternatives + plural alternatives + all alternatives + subcategory
-gender_words_alternatives = list(
+gender_words_data = list(
     zip(
         df_gender["Lemma"],
         df_gender["Word_Type"],
@@ -125,7 +125,7 @@ gender_words_alternatives = list(
 # df gendered no noun
 df_gendered_no_noun = rules["de-DE"]["df_gender_no_noun_word"]
 # gendered: words + alternatives split + subcategory
-gender_words_alternatives_no_noun = list(
+gender_words_data_no_noun = list(
     zip(
         df_gendered_no_noun["Lemma"],
         df_gendered_no_noun["Word_Type"],
@@ -146,7 +146,7 @@ articles = list(
 # df unconscious bias nouns with plural
 df_bias = rules["de-DE"]["df_ub_plur_word"]
 # unconscious bias: words + singular alternatives split + plural alternatives split + subcategory
-bias_words_alternatives_noun = list(
+bias_words_data_noun = list(
     zip(
         df_bias["Lemma"],
         df_bias["Word_Type"],
@@ -158,7 +158,7 @@ bias_words_alternatives_noun = list(
 # df unconscious bias words without plurals
 df_bias_no_plur = rules["de-DE"]["df_ub_no_plur_word"]
 # unconscious bias: words + alternatives split + subcategory
-bias_words_alternatives_no_plur = list(
+bias_words_data_no_plur = list(
     zip(
         df_bias_no_plur["Lemma"],
         df_bias_no_plur["Word_Type"],
@@ -169,7 +169,7 @@ bias_words_alternatives_no_plur = list(
 # df style
 df_style = rules["de-DE"]["df_style_word"]
 # style: words + alternatives + subcategory
-style_words_alternatives = list(
+style_words_data = list(
     zip(
         df_style["Lemma"],
         df_style["Word_Type"],
@@ -180,7 +180,7 @@ style_words_alternatives = list(
 # df open discrimination words
 df_discrimination_words = rules["de-DE"]["df_open_dis_word"]
 # open discrimination: words + alternative_split + subcategory
-open_disc_words_alternatives = list(
+open_disc_words_data = list(
     zip(
         df_discrimination_words["Lemma"],
         df_discrimination_words["Word_Type"],
@@ -204,7 +204,7 @@ abbreviation = list(
 # df open discrimination sentence
 df_discrimination_sentences = rules["de-DE"]["df_open_dis_sentence"]
 # open discrimination: sentences +alternatives split + subcategory
-open_disc_sentences_alternatives = list(
+open_disc_sentences_data = list(
     zip(
         df_discrimination_sentences["Lemma"],
         map(ast.literal_eval, df_discrimination_sentences["Alt_split"]),
@@ -214,7 +214,7 @@ open_disc_sentences_alternatives = list(
 # df gendered sentences
 df_gendered_sentences = rules["de-DE"]["df_gendered_sentences"]
 # gendered: sentences + alternatives split + subcategory
-gender_sentences_alternatives = list(
+gender_sentences_data = list(
     zip(
         df_gendered_sentences["Lemma"],
         map(ast.literal_eval, df_gendered_sentences["Alt_split"]),
@@ -224,7 +224,7 @@ gender_sentences_alternatives = list(
 # df unconscious bias sentences
 df_bias_sentences = rules["de-DE"]["df_ub_sentences"]
 # unconscious bias: sentences + alternatives split + subcategory
-bias_sentences_alternatives = list(
+bias_sentences_data = list(
     zip(
         df_bias_sentences["Lemma"],
         map(ast.literal_eval, df_bias_sentences["Alt_split"]),
@@ -234,7 +234,7 @@ bias_sentences_alternatives = list(
 # df style sentences
 df_style_sentences = rules["de-DE"]["df_style_sentences"]
 # style: sentences + alternatives + subcategory
-style_sentences_alternatives = list(
+style_sentences_data = list(
     zip(
         df_style_sentences["Lemma"],
         map(ast.literal_eval, df_style_sentences["Alt_split"]),
@@ -247,7 +247,7 @@ style_sentences_alternatives = list(
 df_discrimination_US = rules["en-US"]["df_open_dis_word"]
 df_discrimination_GB = rules["en-GB"]["df_open_dis_word"]
 # open discrimination: lemma + alternatives split + subcategory
-open_disc_words_alternatives_US = list(
+open_disc_words_data_US = list(
     zip(
         df_discrimination_US["Lemma"],
         df_discrimination_US["Word_Type"],
@@ -255,7 +255,7 @@ open_disc_words_alternatives_US = list(
         df_discrimination_US["Primary_subcategory"],
     )
 )
-open_disc_words_alternatives_GB = list(
+open_disc_words_data_GB = list(
     zip(
         df_discrimination_GB["Lemma"],
         df_discrimination_GB["Word_Type"],
@@ -267,7 +267,7 @@ open_disc_words_alternatives_GB = list(
 df_gender_no_noun_US = rules["en-US"]["df_gendered_no_noun_word"]
 df_gender_no_noun_GB = rules["en-GB"]["df_gendered_no_noun_word"]
 # gender no noun: lemma + alternatives split + subcategory
-gender_words_alternatives_US = list(
+gender_words_data_US = list(
     zip(
         df_gender_no_noun_US["Lemma"],
         df_gender_no_noun_US["Word_Type"],
@@ -275,7 +275,7 @@ gender_words_alternatives_US = list(
         df_gender_no_noun_US["Primary_subcategory"],
     )
 )
-gender_words_alternatives_GB = list(
+gender_words_data_GB = list(
     zip(
         df_gender_no_noun_GB["Lemma"],
         df_gender_no_noun_GB["Word_Type"],
@@ -287,7 +287,7 @@ gender_words_alternatives_GB = list(
 df_style_US = rules["en-US"]["df_style_word"]
 df_style_GB = rules["en-GB"]["df_style_word"]
 # style: lemma + alternatives split + subcategory
-style_words_alternatives_US = list(
+style_words_data_US = list(
     zip(
         df_style_US["Lemma"],
         df_style_US["Word_Type"],
@@ -295,7 +295,7 @@ style_words_alternatives_US = list(
         df_style_US["Primary_subcategory"],
     )
 )
-style_words_alternatives_GB = list(
+style_words_data_GB = list(
     zip(
         df_style_GB["Lemma"],
         df_style_GB["Word_Type"],
@@ -307,7 +307,7 @@ style_words_alternatives_GB = list(
 df_bias_US = rules["en-US"]["df_ub_no_plur_word"]
 df_bias_GB = rules["en-GB"]["df_ub_no_plur_word"]
 # unconscious bias: lemma + alternatives split + subcategory
-bias_words_alternatives_US = list(
+bias_words_data_US = list(
     zip(
         df_bias_US["Lemma"],
         df_bias_US["Word_Type"],
@@ -315,7 +315,7 @@ bias_words_alternatives_US = list(
         df_bias_US["Primary_subcategory"],
     )
 )
-bias_words_alternatives_GB = list(
+bias_words_data_GB = list(
     zip(
         df_bias_GB["Lemma"],
         df_bias_GB["Word_Type"],
@@ -328,14 +328,14 @@ bias_words_alternatives_GB = list(
 df_inclusive_US = rules["en-US"]["df_inclusive_word"]
 df_inclusive_GB = rules["en-GB"]["df_inclusive_word"]
 # inclusive: lemma + subcategory
-inclusive_words_alternatives_US = list(
+inclusive_words_data_US = list(
     zip(
         df_inclusive_US["Lemma"],
         df_inclusive_US["Word_Type"],
         df_inclusive_US["Primary_subcategory"],
     )
 )
-inclusive_words_alternatives_GB = list(
+inclusive_words_data_GB = list(
     zip(
         df_inclusive_GB["Lemma"],
         df_inclusive_GB["Word_Type"],
@@ -389,7 +389,7 @@ abbreviation_GB = list(
 df_gender_noun_US = rules["en-US"]["df_gendered_noun_word"]
 df_gender_noun_GB = rules["en-GB"]["df_gendered_noun_word"]
 # gendered noun: lemma + singular alternatives split + plural alternatives split + primary subcategory + secondary subcategory
-gender_noun_words_alternatives_US = list(
+gender_noun_words_data_US = list(
     zip(
         df_gender_noun_US["Lemma"],
         df_gender_noun_US["Word_Type"],
@@ -399,7 +399,7 @@ gender_noun_words_alternatives_US = list(
         df_gender_noun_US["Secondary_subcategory"],
     )
 )
-gender_noun_words_alternatives_GB = list(
+gender_noun_words_data_GB = list(
     zip(
         df_gender_noun_GB["Lemma"],
         df_gender_noun_GB["Word_Type"],
@@ -413,7 +413,7 @@ gender_noun_words_alternatives_GB = list(
 df_gendered_ub_US = rules["en-US"]["df_ub_plur_word"]
 df_gendered_ub_GB = rules["en-GB"]["df_ub_plur_word"]
 # gendered unconscious bias plural: lemma + singular alternatives split + plural alternatives split + subcategory
-gender_bias_words_alternatives_US = list(
+gender_bias_words_data_US = list(
     zip(
         df_gendered_ub_US["Lemma"],
         df_gendered_ub_US["Word_Type"],
@@ -423,7 +423,7 @@ gender_bias_words_alternatives_US = list(
         df_gendered_ub_US["Secondary_subcategory"],
     )
 )
-gender_bias_words_alternatives_GB = list(
+gender_bias_words_data_GB = list(
     zip(
         df_gendered_ub_GB["Lemma"],
         df_gendered_ub_US["Word_Type"],
@@ -439,13 +439,13 @@ gender_bias_words_alternatives_GB = list(
 df_inclusive_sentences_US = rules["en-US"]["df_inclusive_sentence"]
 df_inclusive_sentences_GB = rules["en-GB"]["df_inclusive_sentence"]
 # inclusive sentences: lemma + subcategory
-inclusive_sentences_alternatives_US = list(
+inclusive_sentences_data_US = list(
     zip(
         df_inclusive_sentences_US["Lemma"],
         df_inclusive_sentences_US["Primary_subcategory"],
     )
 )
-inclusive_sentences_alternatives_GB = list(
+inclusive_sentences_data_GB = list(
     zip(
         df_inclusive_sentences_GB["Lemma"],
         df_inclusive_sentences_GB["Primary_subcategory"],
@@ -473,14 +473,14 @@ open_dis_sentences_GB = list(
 df_gendered_sentences_US = rules["en-US"]["df_gendered_sentence"]
 df_gendered_sentences_GB = rules["en-GB"]["df_gendered_sentence"]
 # gendered sentences: lemma + alternatives split + primary subcategory
-gender_sentences_alternatives_US = list(
+gender_sentences_data_US = list(
     zip(
         df_gendered_sentences_US["Lemma"],
         map(ast.literal_eval, df_gendered_sentences_US["Alt_split"]),
         df_gendered_sentences_US["Primary_subcategory"],
     )
 )
-gender_sentences_alternatives_GB = list(
+gender_sentences_data_GB = list(
     zip(
         df_gendered_sentences_GB["Lemma"],
         map(ast.literal_eval, df_gendered_sentences_GB["Alt_split"]),
@@ -491,14 +491,14 @@ gender_sentences_alternatives_GB = list(
 df_style_sentences_US = rules["en-US"]["df_style_sentence"]
 df_style_sentences_GB = rules["en-GB"]["df_style_sentence"]
 # style sentences: lemma + alternatives split + subcategory
-style_sentences_alternatives_US = list(
+style_sentences_data_US = list(
     zip(
         df_style_sentences_US["Lemma"],
         map(ast.literal_eval, df_style_sentences_US["Alt_split"]),
         df_style_sentences_US["Primary_subcategory"],
     )
 )
-style_sentences_alternatives_GB = list(
+style_sentences_data_GB = list(
     zip(
         df_style_sentences_GB["Lemma"],
         map(ast.literal_eval, df_style_sentences_GB["Alt_split"]),
@@ -509,14 +509,14 @@ style_sentences_alternatives_GB = list(
 df_bias_sentences_US = rules["en-US"]["df_ub_sentence"]
 df_bias_sentences_GB = rules["en-GB"]["df_ub_sentence"]
 # unconscious bias sentences: lemma + alternatives split + subcategory
-bias_sentences_alternatives_US = list(
+bias_sentences_data_US = list(
     zip(
         df_bias_sentences_US["Lemma"],
         map(ast.literal_eval, df_bias_sentences_US["Alt_split"]),
         df_bias_sentences_US["Primary_subcategory"],
     )
 )
-bias_sentences_alternatives_GB = list(
+bias_sentences_data_GB = list(
     zip(
         df_bias_sentences_GB["Lemma"],
         map(ast.literal_eval, df_bias_sentences_GB["Alt_split"]),

--- a/tests/test_1_1_authenticated_old_format/test_api/input.json
+++ b/tests/test_1_1_authenticated_old_format/test_api/input.json
@@ -1,3 +1,0 @@
-{
-    "text": "Wir suchen Ninja Programmierer für unsere Kunden"
-}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,6 @@ from app.models import (
     LangWithAutoType,
     RequestIn,
 )
-import copy
 
 client = TestClient(app)
 logging.basicConfig(
@@ -31,13 +30,7 @@ def get_dirs(path):
 def test_read_main():
     response = client.get("/", allow_redirects=False)
     assert response.status_code == 301
-    assert response.headers["Location"] == "https://www.witty.works/form"
-
-
-def test_read_form():
-    response = client.get("/form", allow_redirects=False)
-    assert response.status_code == 301
-    assert response.headers["Location"] == "https://www.witty.works/form"
+    assert response.headers["Location"] == "https://www.witty.works/editor"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from app.main import (
     app,
     redis,
-    fetch_user_rules,
+    fetch_rules_for_request,
     is_number_list_empty,
 )
 from app.model import model
@@ -226,84 +226,6 @@ def test_1_1_authenticated_json(test_1_1_authenticated_dir, snapshot, set_redis)
     output = json.dumps(response.json(), sort_keys=True, indent=4, ensure_ascii=False)
     # Snapshot the return value.
     snapshot.snapshot_dir = test_1_1_authenticated_dir
-    snapshot.assert_match(output, "output.json")
-
-
-@pytest.fixture
-def set_redis_1_1():
-    organization_object = {
-        "users": ["test@gmail.com"],
-        "id": "test",
-        "name": "Tests Works",
-        "plan": "witty_teams",
-        "config": {
-            "store_context": {
-                "value": False,
-                "status": "force",
-            },
-            "preferred_variants": {
-                "value": ["en-GB"],
-                "status": "force",
-            },
-            "german_gender_ending": {
-                "value": "In",
-                "status": "force",
-            },
-            "gendered_roles_format": {
-                "value": "binary_gender",
-                "status": "force",
-            },
-            "inclusive": {"value": False, "status": "force"},
-            "orthography": {"value": True, "status": "force"},
-        },
-        "false_positives": [
-            "stark",
-            "starke",
-            "starkes",
-            "starker",
-            "Führungskraft",
-            "Führungskräfte",
-            "Führungskräften",
-        ],
-        "term_replacements": [
-            {
-                "term": "foo",
-                "alternatives": ["bar"],
-                "explanation": {
-                    "text": "better bar",
-                    "icon": "🥰",
-                    "url": "https://witty.works",
-                },
-                "gravity": 3,
-            }
-        ],
-    }
-
-    # Set a value
-    redis.set(organization_object["id"], json.dumps(organization_object))
-    redis.set("test@gmail.com", organization_object["id"])
-
-
-@pytest.mark.parametrize(
-    "test_1_1_authenticated_old_format_dir",
-    get_dirs("tests/test_1_1_authenticated_old_format"),
-)
-def test_1_1_authenticated_old_format_json(
-    test_1_1_authenticated_old_format_dir, snapshot, set_redis_1_1
-):
-    # Read input files from the case directory.
-    input_json = test_1_1_authenticated_old_format_dir.joinpath(
-        "input.json"
-    ).read_text()
-    # Call the tested endpoint.
-    response = client.post(
-        "/v1.1/check", json=json.loads(input_json), headers={"X-Auth": "test@gmail.com"}
-    )
-    assert response.status_code == 200
-    # output must be string
-    output = json.dumps(response.json(), sort_keys=True, indent=4, ensure_ascii=False)
-    # Snapshot the return value.
-    snapshot.snapshot_dir = test_1_1_authenticated_old_format_dir
     snapshot.assert_match(output, "output.json")
 
 
@@ -694,7 +616,7 @@ def test_disable_categories(test_disable_categories_dir, snapshot, set_redis):
 
 
 # test overwriting user configuration by organization forced rules
-def test_fetch_user_rules(event_loop, set_redis):
+def test_fetch_rules_for_request(event_loop, set_redis):
     request_data = {
         "text": "Wir suchen Ninja Programmierer für unsere Kunden",
         "config": {
@@ -707,7 +629,9 @@ def test_fetch_user_rules(event_loop, set_redis):
         },
     }
     test_request = RequestIn(**request_data)
-    event_loop.run_until_complete(fetch_user_rules(test_request, "test@gmail.com"))
+    event_loop.run_until_complete(
+        fetch_rules_for_request(test_request, "test@gmail.com")
+    )
     assert hasattr(test_request.config, "store_context")
     assert test_request.config.store_context == True
     assert test_request.config.preferred_variants == ["en-GB"]
@@ -731,7 +655,7 @@ def test_fetch_user_rules_suggestion(event_loop, set_redis):
     }
     test_request = RequestIn(**request_data)
     event_loop.run_until_complete(
-        fetch_user_rules(test_request, "non_existant@gmail.com")
+        fetch_rules_for_request(test_request, "non_existant@gmail.com")
     )
     assert test_request.config.store_context == True
     assert test_request.config.primary_language == "de-DE"
@@ -749,7 +673,9 @@ def test_set_organization_rules(event_loop, set_redis):
         "text": "Wir suchen Ninja Programmierer für unsere Kunden",
     }
     test_request = RequestIn(**request_data)
-    event_loop.run_until_complete(fetch_user_rules(test_request, "test@gmail.com"))
+    event_loop.run_until_complete(
+        fetch_rules_for_request(test_request, "test@gmail.com")
+    )
     assert test_request.config.store_context == True
     assert test_request.config.preferred_variants == ["en-GB"]
     assert test_request.config.german_gender_ending == "In"
@@ -766,7 +692,7 @@ def test_set_default_rules(event_loop):
     test_request = RequestIn(**request_data)
 
     event_loop.run_until_complete(
-        fetch_user_rules(test_request, "non_existant@gmail.com")
+        fetch_rules_for_request(test_request, "non_existant@gmail.com")
     )
     assert test_request.config.store_context == True
     assert test_request.config.primary_language == None
@@ -874,9 +800,9 @@ def test_store_get_delete_rules():
     response = client.get("/user/rules?email=" + user_request_data["email"])
     assert_rules(response, user_request_data)
 
-    # check user is missing cannot be deleted
+    # check user is missing can be deleted
     response = client.delete("/user/rules?email=foobar")
-    assert response.status_code == 404
+    assert response.status_code == 204
 
     # check user is deleted
     response = client.delete("/user/rules?email=" + user_request_data["email"])
@@ -965,9 +891,9 @@ def test_store_get_delete_rules():
     assert_rules(response, user_request_data)
     assert_rules(response, organization_request_data, "organization_")
 
-    # check organization missing cannot be deleted
+    # check organization missing can be deleted
     response = client.delete("/organization/rules?organization_id=foobar")
-    assert response.status_code == 404
+    assert response.status_code == 204
 
     # check organization deleted
     response = client.delete("/organization/rules?organization_id=TEST_organization")

--- a/tests/test_general_cases/test_api/input.json
+++ b/tests/test_general_cases/test_api/input.json
@@ -1,3 +1,3 @@
 {
-    "text": "Wir suchen Ninja Programmierer für unsere Kunden"
+    "text": "Wir suchen Ninja Programmierer für unsere Kunden und keinen Armleuchter."
 }

--- a/tests/test_general_cases/test_api/output.json
+++ b/tests/test_general_cases/test_api/output.json
@@ -5,6 +5,26 @@
         {
             "alternatives": [
                 {
+                    "remove": true
+                }
+            ],
+            "category": "openly_discriminating",
+            "context": "Wir suchen Ninja Programmierer für unsere Kunden und keinen Armleuchter.",
+            "end": 71,
+            "explanation": {
+                "icon": "🚫",
+                "text": " Verletzt und schüchtert ein",
+                "url": "https://www.witty.works/de/kategorien/offene_diskriminierung#beleidigende_und_einschuechternde_sprache"
+            },
+            "gravity": 1.0,
+            "label": "Offene Diskriminierung: Beleidigende Und Einschüchternde Sprache",
+            "start": 60,
+            "subcategory": "offensive_language",
+            "text": "Armleuchter"
+        },
+        {
+            "alternatives": [
+                {
                     "text": "Auftraggebende"
                 },
                 {
@@ -30,7 +50,7 @@
                 }
             ],
             "category": "gendered",
-            "context": "Wir suchen Ninja Programmierer für unsere Kunden",
+            "context": "Wir suchen Ninja Programmierer für unsere Kunden und keinen Armleuchter.",
             "end": 48,
             "explanation": {
                 "icon": "😟",
@@ -46,7 +66,7 @@
         {
             "alternatives": [],
             "category": "style",
-            "context": "Wir suchen Ninja Programmierer für unsere Kunden",
+            "context": "Wir suchen Ninja Programmierer für unsere Kunden und keinen Armleuchter.",
             "end": 16,
             "explanation": {
                 "icon": "😮‍💨",


### PR DESCRIPTION
this also cleans up the code in other ways:

* merged several of the rule functions to reduce code duplication
* removed redundant code communicating with redis
* aligned function names
  * `fetch` is used for internal functions (so that `get`, `delete`, `post` etc can be used for routes)
  * `_from_redis` reads from redis
  * `_from_request` uses the request data to then read from relevant data sources (ie. redis)

also dropped the `/form` endpoint since it is for quite some time no longer used and redirect to `/editor` and not `/form`