### PR TITLE
renamed 'Category Label' to Anchor and removed unused 'Status' fields

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,18 +44,7 @@ jobs:
         run: |
           wget -P training_data https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin
 
-      - name: Caching translations
-        id: cache-translation-files
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-translation-files
-        with:
-          path: ./locales
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.po') }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
-
       - name: Compile translation
-        if: steps.cache-translation-files.outputs.cache-hit != 'true'
         run: |
           pipenv run pybabel compile -d locales -l de_DE -f
           pipenv run pybabel compile -d locales -l de_AT -f

--- a/app/categories.py
+++ b/app/categories.py
@@ -27,12 +27,6 @@ categories = {
         "importance": 2,
         "emoji": "🤔",
     },
-    "age_in_jobs": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
-    },
     "age_old": {
         "inclusive": False,
         "category": "unconscious_bias",
@@ -46,6 +40,12 @@ categories = {
         "gravity": 2.0,
         "importance": 2,
         "emoji": "😒",
+    },
+    "ageism": {
+        "inclusive": False,
+        "category": "unconscious_bias",
+        "gravity": 3.0,
+        "importance": None,
     },
     "agentic": {
         "inclusive": False,
@@ -151,24 +151,12 @@ categories = {
         "importance": 2,
         "emoji": "✅",
     },
-    "education": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
-    },
     "emotional_security": {
         "inclusive": True,
         "category": "inclusive",
         "gravity": None,
         "importance": 2,
         "emoji": "✅",
-    },
-    "ethnicity": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
     },
     "exaggerating": {
         "inclusive": False,
@@ -372,12 +360,6 @@ categories = {
         "importance": 1,
         "emoji": "❌",
     },
-    "overload": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
-    },
     "passive_voice": {
         "inclusive": False,
         "category": "style",
@@ -405,12 +387,6 @@ categories = {
         "gravity": 2.0,
         "importance": 2,
         "emoji": "😒",
-    },
-    "salary_vague": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
     },
     "sexism": {
         "inclusive": False,
@@ -446,12 +422,6 @@ categories = {
         "gravity": 3.0,
         "importance": None,
     },
-    "technical_frameworks": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
-    },
     "titles": {
         "inclusive": False,
         "category": "gendered",
@@ -473,25 +443,12 @@ categories = {
         "importance": 2,
         "emoji": "😒",
     },
-    "verbose": {
-        "inclusive": False,
-        "category": "style",
-        "gravity": 3.0,
-        "importance": 3,
-        "emoji": "🧊",
-    },
     "vision": {
         "inclusive": False,
         "category": "unconscious_bias",
         "gravity": 2.0,
         "importance": 2,
         "emoji": "😒",
-    },
-    "workload": {
-        "inclusive": False,
-        "category": "job_requirements",
-        "gravity": 3.0,
-        "importance": None,
     },
     "xenophobia": {
         "inclusive": False,

--- a/app/main.py
+++ b/app/main.py
@@ -1113,6 +1113,15 @@ def languagetool_matches(
             except KeyError:
                 pass
 
+        anchor = (
+            label.lower()
+            .replace(" ", "_")
+            .replace("ß", "ss")
+            .replace("ü", "ue")
+            .replace("ä", "ae")
+            .replace("ö", "oe")
+        )
+
         try:
             subcategory = match["rule"]["category"]["id"].lower()
         except KeyError:
@@ -1132,7 +1141,7 @@ def languagetool_matches(
                 start,
                 end,
                 alternatives,
-                label,
+                anchor,
                 explanation,
             )
         )

--- a/app/models.py
+++ b/app/models.py
@@ -382,7 +382,7 @@ class ResultOut(BaseModel):
         start,
         end=None,
         alternatives=None,
-        label=None,
+        anchor=None,
         explanation=None,
         url=None,
         icon=None,
@@ -405,13 +405,14 @@ class ResultOut(BaseModel):
         if subcategory == "gendered_denominations_ending":
             params["gendered_denominations_ending"] = config.german_gender_ending
 
-        label = label if label else lang._("rules." + category + "_label")
+        anchor = anchor if anchor else lang._("rules." + category + "_anchor")
+        sub_anchor = None
 
         if category == "orthography" or category == "corporate_rules":
             category_key = category
         else:
             category_key = subcategory
-            sub_label = lang._("rules." + subcategory + "_label")
+            sub_anchor = lang._("rules." + subcategory + "_anchor")
 
             if url == None:
                 settings = get_settings()
@@ -422,13 +423,14 @@ class ResultOut(BaseModel):
                     + "/"
                     + ("categories" if lang.lang == "en" else "kategorien")
                     + "/"
-                    + ResultOut.transliterate(label)
+                    + anchor
                     + "#"
-                    + ResultOut.transliterate(sub_label)
+                    + sub_anchor
                 )
 
-            if category != subcategory:
-                label += ": " + sub_label
+        label = ResultOut.reverseTransliterate(anchor, lang)
+        if sub_anchor != None and anchor != sub_anchor:
+            label += ": " + ResultOut.reverseTransliterate(sub_anchor, lang)
 
         explanation = (
             explanation
@@ -583,15 +585,13 @@ class ResultOut(BaseModel):
         return False
 
     @staticmethod
-    def transliterate(string):
-        return (
-            string.lower()
-            .replace(" ", "_")
-            .replace("ß", "ss")
-            .replace("ü", "ue")
-            .replace("ä", "ae")
-            .replace("ö", "oe")
-        )
+    def reverseTransliterate(string, lang):
+        string = string.replace("_", " ")
+
+        if lang.lang == "en":
+            return string.capitalize()
+
+        return string.title().replace("ue", "ü").replace("ae", "ä").replace("oe", "ö")
 
     @staticmethod
     def countWords(text):

--- a/bin/update_locales.py
+++ b/bin/update_locales.py
@@ -87,21 +87,17 @@ def read_csv(in_file):
         columns = {
             "Subcategory": 0,
             "Category": None,
-            "Category Label EN": None,
-            "Category Label DE": None,
+            "Anchor EN": None,
+            "Anchor DE": None,
             "Short explanation EN": None,
             "Short explanation DE": None,
-            "Status English": None,
-            "Status German": None,
             "Inclusive?": None,
             "Gravity": None,
             "Importance": None,
-            "Status EN": None,
-            "Status DE": None,
         }
 
         columnMap = {
-            "label": "Category Label",
+            "anchor": "Anchor",
             "explanation": "Short explanation",
         }
 
@@ -120,8 +116,8 @@ def read_csv(in_file):
                 line_count += 1
             else:
                 if (
-                    row[columns["Category Label EN"]] == ""
-                    and row[columns["Category Label DE"]] == ""
+                    row[columns["Anchor EN"]] == ""
+                    and row[columns["Anchor DE"]] == ""
                 ):
                     continue
 

--- a/locales/de_AT/LC_MESSAGES/messages.po
+++ b/locales/de_AT/LC_MESSAGES/messages.po
@@ -3,448 +3,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: engineering@witty.works\n"
-"POT-Creation-Date: 2022-09-13 14:30\n"
-"PO-Revision-Date: 2022-09-13 14:30\n"
+"POT-Creation-Date: 2022-09-19 13:51\n"
+"PO-Revision-Date: 2022-09-19 13:51\n"
 "Last-Translator: engineering@witty.works\n"
 "Language-Team: engineering@witty.works\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "rules.abbreviation_label"
-msgstr "Abkürzung"
+msgid "rules.abbreviation_anchor"
+msgstr "abkuerzung"
 
 msgid "rules.abbreviation_explanation"
 msgstr "Sicher, dass das Lesende verstehen?"
 
-msgid "rules.ability_label"
-msgstr "Fähigkeiten"
+msgid "rules.ability_anchor"
+msgstr "faehigkeiten"
 
 msgid "rules.ability_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Behinderungen"
 
-msgid "rules.ableism_label"
-msgstr "Behindertenfeindlichkeit"
+msgid "rules.ableism_anchor"
+msgstr "behindertenfeindlichkeit"
 
 msgid "rules.ableism_explanation"
 msgstr "Feindlich gegenüber Menschen mit Behinderung"
 
-msgid "rules.age_label"
-msgstr "Altersangabe"
+msgid "rules.age_anchor"
+msgstr "altersangabe"
 
 msgid "rules.age_explanation"
 msgstr "Sicher, dass du das Alter wissen musst?"
 
-msgid "rules.age_in_jobs_label"
-msgstr ""
-
-msgid "rules.age_in_jobs_explanation"
-msgstr ""
-
-msgid "rules.age_old_label"
-msgstr "50 Jahre und älter"
+msgid "rules.age_old_anchor"
+msgstr "50_jahre_und_aelter"
 
 msgid "rules.age_old_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Alter 50+"
 
-msgid "rules.age_young_label"
-msgstr "25 Jahre und jünger"
+msgid "rules.age_young_anchor"
+msgstr "25_jahre_und_juenger"
 
 msgid "rules.age_young_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Alter unter 25"
 
-msgid "rules.agentic_label"
-msgstr "Agentisch"
+msgid "rules.ageism_anchor"
+msgstr "altersdiskriminierungen"
+
+msgid "rules.ageism_explanation"
+msgstr ""
+
+msgid "rules.agentic_anchor"
+msgstr "agentisch"
 
 msgid "rules.agentic_explanation"
 msgstr "Fühlt sich weder kooperativ noch unterstützend an"
 
-msgid "rules.anglicism_label"
-msgstr "Anglizismen"
+msgid "rules.anglicism_anchor"
+msgstr "anglizismen"
 
 msgid "rules.anglicism_explanation"
 msgstr "Anglizismen: Sicher, dass das alle Lesenden verstehen?"
 
-msgid "rules.antimuslim_label"
-msgstr "Islamophobie"
+msgid "rules.antimuslim_anchor"
+msgstr "islamophobie"
 
 msgid "rules.antimuslim_explanation"
 msgstr "Islamophob"
 
-msgid "rules.antisemitism_label"
-msgstr "Anti-Semitismus"
+msgid "rules.antisemitism_anchor"
+msgstr "anti-semitismus"
 
 msgid "rules.antisemitism_explanation"
 msgstr "Anti-semitisch"
 
-msgid "rules.behavior_label"
-msgstr "Verhalten"
+msgid "rules.behavior_anchor"
+msgstr "verhalten"
 
 msgid "rules.behavior_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Verhalten"
 
-msgid "rules.belief_label"
-msgstr "Glauben"
+msgid "rules.belief_anchor"
+msgstr "glauben"
 
 msgid "rules.belief_explanation"
 msgstr "Glauben ausdrückend; stimmt nicht für alle"
 
-msgid "rules.binary_pronouns_label"
-msgstr "Binäre Pronomen"
+msgid "rules.binary_pronouns_anchor"
+msgstr "binaere_pronomen"
 
 msgid "rules.binary_pronouns_explanation"
 msgstr "Pronomen gemäss binärem Geschlechterverständnis"
 
-msgid "rules.caring_label"
-msgstr "Einfühlsam"
+msgid "rules.caring_anchor"
+msgstr "einfühlsam"
 
 msgid "rules.caring_explanation"
 msgstr "Betont Offenheit, Fürsorge und Interesse"
 
-msgid "rules.classism_label"
-msgstr "Klassismus"
+msgid "rules.classism_anchor"
+msgstr "klassismus"
 
 msgid "rules.classism_explanation"
 msgstr "Drückt Machtungleichgewicht aus"
 
-msgid "rules.cognitive_ability_label"
-msgstr "Denkfähigkeit"
+msgid "rules.cognitive_ability_anchor"
+msgstr "denkfaehigkeit"
 
 msgid "rules.cognitive_ability_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Lernfähigkeit"
 
-msgid "rules.cognitive_perception_label"
-msgstr "Wahrnehmung"
+msgid "rules.cognitive_perception_anchor"
+msgstr "wahrnehmung"
 
 msgid "rules.cognitive_perception_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich kognitiver Wahrnehmung"
 
-msgid "rules.communal_label"
-msgstr "Kommunal"
+msgid "rules.communal_anchor"
+msgstr "kommunal"
 
 msgid "rules.communal_explanation"
 msgstr "Betont kooperative Eigenschaften"
 
-msgid "rules.corporate_rules_label"
-msgstr "Organisations-Leitlinie"
+msgid "rules.corporate_rules_anchor"
+msgstr "organisations_leitlinie"
 
 msgid "rules.corporate_rules_explanation"
 msgstr "Wir schreiben lieber"
 
-msgid "rules.culture_label"
-msgstr "Kultur"
+msgid "rules.culture_anchor"
+msgstr "kultur"
 
 msgid "rules.culture_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich kulturellem Hintergrund"
 
-msgid "rules.d_and_i_label"
-msgstr "Diversität & Inklusion"
+msgid "rules.d_and_i_anchor"
+msgstr "diversitaet_&_inklusion"
 
 msgid "rules.d_and_i_explanation"
 msgstr "Bestärkt Wert von Diversity, Gleichstellung und Inklusion"
 
-msgid "rules.education_label"
-msgstr ""
-
-msgid "rules.education_explanation"
-msgstr ""
-
-msgid "rules.emotional_security_label"
+msgid "rules.emotional_security_anchor"
 msgstr ""
 
 msgid "rules.emotional_security_explanation"
 msgstr "Vermittelt emotionale Sicherheit"
 
-msgid "rules.ethnicity_label"
-msgstr ""
-
-msgid "rules.ethnicity_explanation"
-msgstr ""
-
-msgid "rules.exaggerating_label"
-msgstr "Superlative"
+msgid "rules.exaggerating_anchor"
+msgstr "superlative"
 
 msgid "rules.exaggerating_explanation"
 msgstr "Superlative: als Druck oder Arroganz wahrgenommen"
 
-msgid "rules.female_stereotype_label"
-msgstr "Weiblicher Stereotyp"
+msgid "rules.female_stereotype_anchor"
+msgstr "weiblicher_stereotyp"
 
 msgid "rules.female_stereotype_explanation"
 msgstr "Steckt Frauen in traditionelle Rollen"
 
-msgid "rules.filler_label"
-msgstr "Füllwörter"
+msgid "rules.filler_anchor"
+msgstr "fuellwoerter"
 
 msgid "rules.filler_explanation"
 msgstr "Füllwörter machen das Verständnis schwieriger"
 
-msgid "rules.formality_label"
-msgstr "Formalität"
+msgid "rules.formality_anchor"
+msgstr "formalitaet"
 
 msgid "rules.formality_explanation"
 msgstr "Formale Formulierung kreiert emotionale Distanz"
 
-msgid "rules.function_label"
-msgstr "Spezielle Funktionen"
+msgid "rules.function_anchor"
+msgstr "spezielle_funktionen"
 
 msgid "rules.function_explanation"
 msgstr "Bild eines Mannes wird unbewusst ausgelöst"
 
-msgid "rules.gen_boomer_label"
-msgstr "Sprache Generation Boomer & X"
+msgid "rules.gen_boomer_anchor"
+msgstr "sprach_generation_boomer_&_X"
 
 msgid "rules.gen_boomer_explanation"
 msgstr "Selten bekannte Formulierung der Generation Boomer"
 
-msgid "rules.gen_z_label"
-msgstr "Gen Z Language"
+msgid "rules.gen_z_anchor"
+msgstr "gen_z_sprache"
 
 msgid "rules.gen_z_explanation"
 msgstr "Nicht allen bekannte Formulierung der Generation Z"
 
-msgid "rules.gender_identity_label"
-msgstr "Geschlechtsidentität"
+msgid "rules.gender_identity_anchor"
+msgstr "geschlechtsidentitaet"
 
 msgid "rules.gender_identity_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Geschlechtsidentität"
 
-msgid "rules.gendered_label"
-msgstr "Geschlechtsspezifisch"
+msgid "rules.gendered_anchor"
+msgstr "geschlechtsspezifisch"
 
 msgid "rules.gendered_explanation"
 msgstr "Schubladendenken nach Geschlechternormen"
 
-msgid "rules.gendered_denominations_ending_label"
-msgstr "Inklusive Endung"
+msgid "rules.gendered_denominations_ending_anchor"
+msgstr "inklusive_endung"
 
 msgid "rules.gendered_denominations_ending_explanation"
 msgstr "Nicht konsistente Geschlechts-Schreibweise"
 
-msgid "rules.generic_plural_label"
-msgstr "Generisches Plural"
+msgid "rules.generic_plural_anchor"
+msgstr "generisches_plural"
 
 msgid "rules.generic_plural_explanation"
 msgstr "Geschlechtsspezifisches Bild stark verankert. Im Plural weniger."
 
-msgid "rules.hearing_label"
-msgstr "Hör-Fähigkeit"
+msgid "rules.hearing_anchor"
+msgstr "hoer_faehigkeit"
 
 msgid "rules.hearing_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Hör-Fähigkeit"
 
-msgid "rules.hidden_image_label"
-msgstr "Versteckter Ausdruck"
+msgid "rules.hidden_image_anchor"
+msgstr "versteckter_ausdruck"
 
 msgid "rules.hidden_image_explanation"
 msgstr "Verstecktes männliches Generikum"
 
-msgid "rules.hollow_label"
-msgstr "Worthülsen"
+msgid "rules.hollow_anchor"
+msgstr "worthuelsen"
 
 msgid "rules.hollow_explanation"
 msgstr "Worthülsen haben ihre Bedeutung verloren"
 
-msgid "rules.homophobia_label"
-msgstr "Homophobie"
+msgid "rules.homophobia_anchor"
+msgstr "homophobie"
 
 msgid "rules.homophobia_explanation"
 msgstr "Homophob"
 
-msgid "rules.inclusive_label"
-msgstr "Inklusiv"
+msgid "rules.inclusive_anchor"
+msgstr "inklusiv"
 
 msgid "rules.inclusive_explanation"
 msgstr "Lässt Zugehörigkeitsgefühl entstehen"
 
-msgid "rules.job_requirements_label"
-msgstr "Voreingenommene Anforderungen"
+msgid "rules.job_requirements_anchor"
+msgstr "voreingenommene_anforderungen"
 
 msgid "rules.job_requirements_explanation"
 msgstr ""
 
-msgid "rules.leadership_label"
-msgstr "Führungsstereotyp"
+msgid "rules.leadership_anchor"
+msgstr "fuehrungsstereotyp"
 
 msgid "rules.leadership_explanation"
 msgstr "Traditionelles Führungs-Vokabular"
 
-msgid "rules.learning_label"
-msgstr "Lernfähigkeit"
+msgid "rules.learning_anchor"
+msgstr "lernfaehigkeit"
 
 msgid "rules.learning_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Lernfähigkeit"
 
-msgid "rules.male_stereotype_label"
-msgstr "Männlicher Stereotyp"
+msgid "rules.male_stereotype_anchor"
+msgstr "maennlicher_stereotyp"
 
 msgid "rules.male_stereotype_explanation"
 msgstr "Steckt Männer in traditionelle Rollen"
 
-msgid "rules.medical_state_label"
-msgstr "Gesundheitsbild"
+msgid "rules.medical_state_anchor"
+msgstr "gesundheitsbild"
 
 msgid "rules.medical_state_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Gesundheitsbild"
 
-msgid "rules.mental_wellbeing_label"
-msgstr "Mentales Wohlbefinden"
+msgid "rules.mental_wellbeing_anchor"
+msgstr "mentales_wohlbefinden"
 
 msgid "rules.mental_wellbeing_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich mentalem Wohlbefinden"
 
-msgid "rules.migration_label"
-msgstr "Migrationshintergrund"
+msgid "rules.migration_anchor"
+msgstr "migrationshintergrund"
 
 msgid "rules.migration_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Migrationshintergrund"
 
-msgid "rules.military_source_label"
-msgstr "Militärische Wurzel"
+msgid "rules.military_source_anchor"
+msgstr "militaerische_wurzel"
 
 msgid "rules.military_source_explanation"
 msgstr "Militärischer Begriff kommuniziert kriegsähnlichen Zustand"
 
-msgid "rules.misgendering_institutions_label"
-msgstr "Geschlecht von Institutionen"
+msgid "rules.misgendering_institutions_anchor"
+msgstr "geschlecht_von_institutionen"
 
 msgid "rules.misgendering_institutions_explanation"
 msgstr "Falsche Verwendung des grammatikalischen Geschlechtes"
 
-msgid "rules.mobility_label"
-msgstr "Mobilität"
+msgid "rules.mobility_anchor"
+msgstr "mobilitaet"
 
 msgid "rules.mobility_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Mobilität"
 
-msgid "rules.offensive_language_label"
-msgstr "Beleidigende und einschüchternde Sprache"
+msgid "rules.offensive_language_anchor"
+msgstr "beleidigende_und_einschuechternde_sprache"
 
 msgid "rules.offensive_language_explanation"
 msgstr " Verletzt und schüchtert ein"
 
-msgid "rules.openly_discriminating_label"
-msgstr "Offene Diskriminierung"
+msgid "rules.openly_discriminating_anchor"
+msgstr "offene_diskriminierung"
 
 msgid "rules.openly_discriminating_explanation"
 msgstr ""
 
-msgid "rules.orthography_label"
-msgstr "Orthographie"
+msgid "rules.orthography_anchor"
+msgstr "orthographie"
 
 msgid "rules.orthography_explanation"
 msgstr "Orthographie"
 
-msgid "rules.overload_label"
-msgstr ""
-
-msgid "rules.overload_explanation"
-msgstr ""
-
-msgid "rules.passive_voice_label"
-msgstr "Passiv-Form"
+msgid "rules.passive_voice_anchor"
+msgstr "passiv_form"
 
 msgid "rules.passive_voice_explanation"
 msgstr "Durch Passiv-Form entsteht emotionale Distanz"
 
-msgid "rules.pressure_label"
-msgstr "Druck"
+msgid "rules.pressure_anchor"
+msgstr "druck"
 
 msgid "rules.pressure_explanation"
 msgstr "Kommuniziert Druck"
 
-msgid "rules.racism_label"
-msgstr "Rassismus"
+msgid "rules.racism_anchor"
+msgstr "rassismus"
 
 msgid "rules.racism_explanation"
 msgstr "Rassistisch"
 
-msgid "rules.racist_source_label"
-msgstr "Rassistische Wurzel"
+msgid "rules.racist_source_anchor"
+msgstr "rassistische_wurzel"
 
 msgid "rules.racist_source_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Hautfarbe"
 
-msgid "rules.salary_vague_label"
-msgstr ""
-
-msgid "rules.salary_vague_explanation"
-msgstr ""
-
-msgid "rules.sexism_label"
-msgstr "Sexismus"
+msgid "rules.sexism_anchor"
+msgstr "sexismus"
 
 msgid "rules.sexism_explanation"
 msgstr "Frauenfeindlich"
 
-msgid "rules.sexual_orientation_label"
-msgstr "Sexuelle Orientierung"
+msgid "rules.sexual_orientation_anchor"
+msgstr "sexuelle_orientierung"
 
 msgid "rules.sexual_orientation_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich sexueller Orientierung"
 
-msgid "rules.speech_label"
-msgstr "Sprech-Fähigkeit"
+msgid "rules.speech_anchor"
+msgstr "sprech_faehigkeit"
 
 msgid "rules.speech_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Sprech-Fähigkeit"
 
-msgid "rules.sports_terms_label"
-msgstr "Sport-Jargon"
+msgid "rules.sports_terms_anchor"
+msgstr "sport_jargon"
 
 msgid "rules.sports_terms_explanation"
 msgstr "Sportlicher Begriff drückt Wettbewerbsstimmung aus"
 
-msgid "rules.style_label"
-msgstr "Stil"
+msgid "rules.style_anchor"
+msgstr "stil"
 
 msgid "rules.style_explanation"
 msgstr ""
 
-msgid "rules.technical_frameworks_label"
-msgstr ""
-
-msgid "rules.technical_frameworks_explanation"
-msgstr ""
-
-msgid "rules.titles_label"
-msgstr "Titel"
+msgid "rules.titles_anchor"
+msgstr "titel"
 
 msgid "rules.titles_explanation"
 msgstr "“Mitmeinen” mit männlichen Generikum funktioniert nicht"
 
-msgid "rules.transphobia_label"
-msgstr "Transphobie"
+msgid "rules.transphobia_anchor"
+msgstr "transphobie"
 
 msgid "rules.transphobia_explanation"
 msgstr "Transphob"
 
-msgid "rules.unconscious_bias_label"
-msgstr "Sprachliche Voreingenommenheit"
+msgid "rules.unconscious_bias_anchor"
+msgstr "sprachliche_voreingenommenheit"
 
 msgid "rules.unconscious_bias_explanation"
 msgstr "Wort, das eine Voreingenommenheit kommuniziert, auf versteckte Art"
 
-msgid "rules.verbose_label"
-msgstr ""
-
-msgid "rules.verbose_explanation"
-msgstr "Durch ‘Nominalistil’ entsteht Distanz"
-
-msgid "rules.vision_label"
-msgstr "Seh-Fähigkeit"
+msgid "rules.vision_anchor"
+msgstr "seh_faehigkeit"
 
 msgid "rules.vision_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Seh-Fähigkeit"
 
-msgid "rules.workload_label"
-msgstr ""
-
-msgid "rules.workload_explanation"
-msgstr ""
-
-msgid "rules.xenophobia_label"
-msgstr "Xenophobie/Fremdenfeindlichkeit"
+msgid "rules.xenophobia_anchor"
+msgstr "xenophobie/fremdenfeindlichkeit"
 
 msgid "rules.xenophobia_explanation"
 msgstr "Fremdenfeindlich, xenophob"

--- a/locales/de_CH/LC_MESSAGES/messages.po
+++ b/locales/de_CH/LC_MESSAGES/messages.po
@@ -3,448 +3,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: engineering@witty.works\n"
-"POT-Creation-Date: 2022-09-13 14:30\n"
-"PO-Revision-Date: 2022-09-13 14:30\n"
+"POT-Creation-Date: 2022-09-19 13:51\n"
+"PO-Revision-Date: 2022-09-19 13:51\n"
 "Last-Translator: engineering@witty.works\n"
 "Language-Team: engineering@witty.works\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "rules.abbreviation_label"
-msgstr "Abkürzung"
+msgid "rules.abbreviation_anchor"
+msgstr "abkuerzung"
 
 msgid "rules.abbreviation_explanation"
 msgstr "Sicher, dass das Lesende verstehen?"
 
-msgid "rules.ability_label"
-msgstr "Fähigkeiten"
+msgid "rules.ability_anchor"
+msgstr "faehigkeiten"
 
 msgid "rules.ability_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Behinderungen"
 
-msgid "rules.ableism_label"
-msgstr "Behindertenfeindlichkeit"
+msgid "rules.ableism_anchor"
+msgstr "behindertenfeindlichkeit"
 
 msgid "rules.ableism_explanation"
 msgstr "Feindlich gegenüber Menschen mit Behinderung"
 
-msgid "rules.age_label"
-msgstr "Altersangabe"
+msgid "rules.age_anchor"
+msgstr "altersangabe"
 
 msgid "rules.age_explanation"
 msgstr "Sicher, dass du das Alter wissen musst?"
 
-msgid "rules.age_in_jobs_label"
-msgstr ""
-
-msgid "rules.age_in_jobs_explanation"
-msgstr ""
-
-msgid "rules.age_old_label"
-msgstr "50 Jahre und älter"
+msgid "rules.age_old_anchor"
+msgstr "50_jahre_und_aelter"
 
 msgid "rules.age_old_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Alter 50+"
 
-msgid "rules.age_young_label"
-msgstr "25 Jahre und jünger"
+msgid "rules.age_young_anchor"
+msgstr "25_jahre_und_juenger"
 
 msgid "rules.age_young_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Alter unter 25"
 
-msgid "rules.agentic_label"
-msgstr "Agentisch"
+msgid "rules.ageism_anchor"
+msgstr "altersdiskriminierungen"
+
+msgid "rules.ageism_explanation"
+msgstr ""
+
+msgid "rules.agentic_anchor"
+msgstr "agentisch"
 
 msgid "rules.agentic_explanation"
 msgstr "Fühlt sich weder kooperativ noch unterstützend an"
 
-msgid "rules.anglicism_label"
-msgstr "Anglizismen"
+msgid "rules.anglicism_anchor"
+msgstr "anglizismen"
 
 msgid "rules.anglicism_explanation"
 msgstr "Anglizismen: Sicher, dass das alle Lesenden verstehen?"
 
-msgid "rules.antimuslim_label"
-msgstr "Islamophobie"
+msgid "rules.antimuslim_anchor"
+msgstr "islamophobie"
 
 msgid "rules.antimuslim_explanation"
 msgstr "Islamophob"
 
-msgid "rules.antisemitism_label"
-msgstr "Anti-Semitismus"
+msgid "rules.antisemitism_anchor"
+msgstr "anti-semitismus"
 
 msgid "rules.antisemitism_explanation"
 msgstr "Anti-semitisch"
 
-msgid "rules.behavior_label"
-msgstr "Verhalten"
+msgid "rules.behavior_anchor"
+msgstr "verhalten"
 
 msgid "rules.behavior_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Verhalten"
 
-msgid "rules.belief_label"
-msgstr "Glauben"
+msgid "rules.belief_anchor"
+msgstr "glauben"
 
 msgid "rules.belief_explanation"
 msgstr "Glauben ausdrückend; stimmt nicht für alle"
 
-msgid "rules.binary_pronouns_label"
-msgstr "Binäre Pronomen"
+msgid "rules.binary_pronouns_anchor"
+msgstr "binaere_pronomen"
 
 msgid "rules.binary_pronouns_explanation"
 msgstr "Pronomen gemäss binärem Geschlechterverständnis"
 
-msgid "rules.caring_label"
-msgstr "Einfühlsam"
+msgid "rules.caring_anchor"
+msgstr "einfühlsam"
 
 msgid "rules.caring_explanation"
 msgstr "Betont Offenheit, Fürsorge und Interesse"
 
-msgid "rules.classism_label"
-msgstr "Klassismus"
+msgid "rules.classism_anchor"
+msgstr "klassismus"
 
 msgid "rules.classism_explanation"
 msgstr "Drückt Machtungleichgewicht aus"
 
-msgid "rules.cognitive_ability_label"
-msgstr "Denkfähigkeit"
+msgid "rules.cognitive_ability_anchor"
+msgstr "denkfaehigkeit"
 
 msgid "rules.cognitive_ability_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Lernfähigkeit"
 
-msgid "rules.cognitive_perception_label"
-msgstr "Wahrnehmung"
+msgid "rules.cognitive_perception_anchor"
+msgstr "wahrnehmung"
 
 msgid "rules.cognitive_perception_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich kognitiver Wahrnehmung"
 
-msgid "rules.communal_label"
-msgstr "Kommunal"
+msgid "rules.communal_anchor"
+msgstr "kommunal"
 
 msgid "rules.communal_explanation"
 msgstr "Betont kooperative Eigenschaften"
 
-msgid "rules.corporate_rules_label"
-msgstr "Organisations-Leitlinie"
+msgid "rules.corporate_rules_anchor"
+msgstr "organisations_leitlinie"
 
 msgid "rules.corporate_rules_explanation"
 msgstr "Wir schreiben lieber"
 
-msgid "rules.culture_label"
-msgstr "Kultur"
+msgid "rules.culture_anchor"
+msgstr "kultur"
 
 msgid "rules.culture_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich kulturellem Hintergrund"
 
-msgid "rules.d_and_i_label"
-msgstr "Diversität & Inklusion"
+msgid "rules.d_and_i_anchor"
+msgstr "diversitaet_&_inklusion"
 
 msgid "rules.d_and_i_explanation"
 msgstr "Bestärkt Wert von Diversity, Gleichstellung und Inklusion"
 
-msgid "rules.education_label"
-msgstr ""
-
-msgid "rules.education_explanation"
-msgstr ""
-
-msgid "rules.emotional_security_label"
+msgid "rules.emotional_security_anchor"
 msgstr ""
 
 msgid "rules.emotional_security_explanation"
 msgstr "Vermittelt emotionale Sicherheit"
 
-msgid "rules.ethnicity_label"
-msgstr ""
-
-msgid "rules.ethnicity_explanation"
-msgstr ""
-
-msgid "rules.exaggerating_label"
-msgstr "Superlative"
+msgid "rules.exaggerating_anchor"
+msgstr "superlative"
 
 msgid "rules.exaggerating_explanation"
 msgstr "Superlative: als Druck oder Arroganz wahrgenommen"
 
-msgid "rules.female_stereotype_label"
-msgstr "Weiblicher Stereotyp"
+msgid "rules.female_stereotype_anchor"
+msgstr "weiblicher_stereotyp"
 
 msgid "rules.female_stereotype_explanation"
 msgstr "Steckt Frauen in traditionelle Rollen"
 
-msgid "rules.filler_label"
-msgstr "Füllwörter"
+msgid "rules.filler_anchor"
+msgstr "fuellwoerter"
 
 msgid "rules.filler_explanation"
 msgstr "Füllwörter machen das Verständnis schwieriger"
 
-msgid "rules.formality_label"
-msgstr "Formalität"
+msgid "rules.formality_anchor"
+msgstr "formalitaet"
 
 msgid "rules.formality_explanation"
 msgstr "Formale Formulierung kreiert emotionale Distanz"
 
-msgid "rules.function_label"
-msgstr "Spezielle Funktionen"
+msgid "rules.function_anchor"
+msgstr "spezielle_funktionen"
 
 msgid "rules.function_explanation"
 msgstr "Bild eines Mannes wird unbewusst ausgelöst"
 
-msgid "rules.gen_boomer_label"
-msgstr "Sprache Generation Boomer & X"
+msgid "rules.gen_boomer_anchor"
+msgstr "sprach_generation_boomer_&_X"
 
 msgid "rules.gen_boomer_explanation"
 msgstr "Selten bekannte Formulierung der Generation Boomer"
 
-msgid "rules.gen_z_label"
-msgstr "Gen Z Language"
+msgid "rules.gen_z_anchor"
+msgstr "gen_z_sprache"
 
 msgid "rules.gen_z_explanation"
 msgstr "Nicht allen bekannte Formulierung der Generation Z"
 
-msgid "rules.gender_identity_label"
-msgstr "Geschlechtsidentität"
+msgid "rules.gender_identity_anchor"
+msgstr "geschlechtsidentitaet"
 
 msgid "rules.gender_identity_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Geschlechtsidentität"
 
-msgid "rules.gendered_label"
-msgstr "Geschlechtsspezifisch"
+msgid "rules.gendered_anchor"
+msgstr "geschlechtsspezifisch"
 
 msgid "rules.gendered_explanation"
 msgstr "Schubladendenken nach Geschlechternormen"
 
-msgid "rules.gendered_denominations_ending_label"
-msgstr "Inklusive Endung"
+msgid "rules.gendered_denominations_ending_anchor"
+msgstr "inklusive_endung"
 
 msgid "rules.gendered_denominations_ending_explanation"
 msgstr "Nicht konsistente Geschlechts-Schreibweise"
 
-msgid "rules.generic_plural_label"
-msgstr "Generisches Plural"
+msgid "rules.generic_plural_anchor"
+msgstr "generisches_plural"
 
 msgid "rules.generic_plural_explanation"
 msgstr "Geschlechtsspezifisches Bild stark verankert. Im Plural weniger."
 
-msgid "rules.hearing_label"
-msgstr "Hör-Fähigkeit"
+msgid "rules.hearing_anchor"
+msgstr "hoer_faehigkeit"
 
 msgid "rules.hearing_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Hör-Fähigkeit"
 
-msgid "rules.hidden_image_label"
-msgstr "Versteckter Ausdruck"
+msgid "rules.hidden_image_anchor"
+msgstr "versteckter_ausdruck"
 
 msgid "rules.hidden_image_explanation"
 msgstr "Verstecktes männliches Generikum"
 
-msgid "rules.hollow_label"
-msgstr "Worthülsen"
+msgid "rules.hollow_anchor"
+msgstr "worthuelsen"
 
 msgid "rules.hollow_explanation"
 msgstr "Worthülsen haben ihre Bedeutung verloren"
 
-msgid "rules.homophobia_label"
-msgstr "Homophobie"
+msgid "rules.homophobia_anchor"
+msgstr "homophobie"
 
 msgid "rules.homophobia_explanation"
 msgstr "Homophob"
 
-msgid "rules.inclusive_label"
-msgstr "Inklusiv"
+msgid "rules.inclusive_anchor"
+msgstr "inklusiv"
 
 msgid "rules.inclusive_explanation"
 msgstr "Lässt Zugehörigkeitsgefühl entstehen"
 
-msgid "rules.job_requirements_label"
-msgstr "Voreingenommene Anforderungen"
+msgid "rules.job_requirements_anchor"
+msgstr "voreingenommene_anforderungen"
 
 msgid "rules.job_requirements_explanation"
 msgstr ""
 
-msgid "rules.leadership_label"
-msgstr "Führungsstereotyp"
+msgid "rules.leadership_anchor"
+msgstr "fuehrungsstereotyp"
 
 msgid "rules.leadership_explanation"
 msgstr "Traditionelles Führungs-Vokabular"
 
-msgid "rules.learning_label"
-msgstr "Lernfähigkeit"
+msgid "rules.learning_anchor"
+msgstr "lernfaehigkeit"
 
 msgid "rules.learning_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Lernfähigkeit"
 
-msgid "rules.male_stereotype_label"
-msgstr "Männlicher Stereotyp"
+msgid "rules.male_stereotype_anchor"
+msgstr "maennlicher_stereotyp"
 
 msgid "rules.male_stereotype_explanation"
 msgstr "Steckt Männer in traditionelle Rollen"
 
-msgid "rules.medical_state_label"
-msgstr "Gesundheitsbild"
+msgid "rules.medical_state_anchor"
+msgstr "gesundheitsbild"
 
 msgid "rules.medical_state_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Gesundheitsbild"
 
-msgid "rules.mental_wellbeing_label"
-msgstr "Mentales Wohlbefinden"
+msgid "rules.mental_wellbeing_anchor"
+msgstr "mentales_wohlbefinden"
 
 msgid "rules.mental_wellbeing_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich mentalem Wohlbefinden"
 
-msgid "rules.migration_label"
-msgstr "Migrationshintergrund"
+msgid "rules.migration_anchor"
+msgstr "migrationshintergrund"
 
 msgid "rules.migration_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Migrationshintergrund"
 
-msgid "rules.military_source_label"
-msgstr "Militärische Wurzel"
+msgid "rules.military_source_anchor"
+msgstr "militaerische_wurzel"
 
 msgid "rules.military_source_explanation"
 msgstr "Militärischer Begriff kommuniziert kriegsähnlichen Zustand"
 
-msgid "rules.misgendering_institutions_label"
-msgstr "Geschlecht von Institutionen"
+msgid "rules.misgendering_institutions_anchor"
+msgstr "geschlecht_von_institutionen"
 
 msgid "rules.misgendering_institutions_explanation"
 msgstr "Falsche Verwendung des grammatikalischen Geschlechtes"
 
-msgid "rules.mobility_label"
-msgstr "Mobilität"
+msgid "rules.mobility_anchor"
+msgstr "mobilitaet"
 
 msgid "rules.mobility_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Mobilität"
 
-msgid "rules.offensive_language_label"
-msgstr "Beleidigende und einschüchternde Sprache"
+msgid "rules.offensive_language_anchor"
+msgstr "beleidigende_und_einschuechternde_sprache"
 
 msgid "rules.offensive_language_explanation"
 msgstr " Verletzt und schüchtert ein"
 
-msgid "rules.openly_discriminating_label"
-msgstr "Offene Diskriminierung"
+msgid "rules.openly_discriminating_anchor"
+msgstr "offene_diskriminierung"
 
 msgid "rules.openly_discriminating_explanation"
 msgstr ""
 
-msgid "rules.orthography_label"
-msgstr "Orthographie"
+msgid "rules.orthography_anchor"
+msgstr "orthographie"
 
 msgid "rules.orthography_explanation"
 msgstr "Orthographie"
 
-msgid "rules.overload_label"
-msgstr ""
-
-msgid "rules.overload_explanation"
-msgstr ""
-
-msgid "rules.passive_voice_label"
-msgstr "Passiv-Form"
+msgid "rules.passive_voice_anchor"
+msgstr "passiv_form"
 
 msgid "rules.passive_voice_explanation"
 msgstr "Durch Passiv-Form entsteht emotionale Distanz"
 
-msgid "rules.pressure_label"
-msgstr "Druck"
+msgid "rules.pressure_anchor"
+msgstr "druck"
 
 msgid "rules.pressure_explanation"
 msgstr "Kommuniziert Druck"
 
-msgid "rules.racism_label"
-msgstr "Rassismus"
+msgid "rules.racism_anchor"
+msgstr "rassismus"
 
 msgid "rules.racism_explanation"
 msgstr "Rassistisch"
 
-msgid "rules.racist_source_label"
-msgstr "Rassistische Wurzel"
+msgid "rules.racist_source_anchor"
+msgstr "rassistische_wurzel"
 
 msgid "rules.racist_source_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Hautfarbe"
 
-msgid "rules.salary_vague_label"
-msgstr ""
-
-msgid "rules.salary_vague_explanation"
-msgstr ""
-
-msgid "rules.sexism_label"
-msgstr "Sexismus"
+msgid "rules.sexism_anchor"
+msgstr "sexismus"
 
 msgid "rules.sexism_explanation"
 msgstr "Frauenfeindlich"
 
-msgid "rules.sexual_orientation_label"
-msgstr "Sexuelle Orientierung"
+msgid "rules.sexual_orientation_anchor"
+msgstr "sexuelle_orientierung"
 
 msgid "rules.sexual_orientation_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich sexueller Orientierung"
 
-msgid "rules.speech_label"
-msgstr "Sprech-Fähigkeit"
+msgid "rules.speech_anchor"
+msgstr "sprech_faehigkeit"
 
 msgid "rules.speech_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Sprech-Fähigkeit"
 
-msgid "rules.sports_terms_label"
-msgstr "Sport-Jargon"
+msgid "rules.sports_terms_anchor"
+msgstr "sport_jargon"
 
 msgid "rules.sports_terms_explanation"
 msgstr "Sportlicher Begriff drückt Wettbewerbsstimmung aus"
 
-msgid "rules.style_label"
-msgstr "Stil"
+msgid "rules.style_anchor"
+msgstr "stil"
 
 msgid "rules.style_explanation"
 msgstr ""
 
-msgid "rules.technical_frameworks_label"
-msgstr ""
-
-msgid "rules.technical_frameworks_explanation"
-msgstr ""
-
-msgid "rules.titles_label"
-msgstr "Titel"
+msgid "rules.titles_anchor"
+msgstr "titel"
 
 msgid "rules.titles_explanation"
 msgstr "“Mitmeinen” mit männlichen Generikum funktioniert nicht"
 
-msgid "rules.transphobia_label"
-msgstr "Transphobie"
+msgid "rules.transphobia_anchor"
+msgstr "transphobie"
 
 msgid "rules.transphobia_explanation"
 msgstr "Transphob"
 
-msgid "rules.unconscious_bias_label"
-msgstr "Sprachliche Voreingenommenheit"
+msgid "rules.unconscious_bias_anchor"
+msgstr "sprachliche_voreingenommenheit"
 
 msgid "rules.unconscious_bias_explanation"
 msgstr "Wort, das eine Voreingenommenheit kommuniziert, auf versteckte Art"
 
-msgid "rules.verbose_label"
-msgstr ""
-
-msgid "rules.verbose_explanation"
-msgstr "Durch ‘Nominalistil’ entsteht Distanz"
-
-msgid "rules.vision_label"
-msgstr "Seh-Fähigkeit"
+msgid "rules.vision_anchor"
+msgstr "seh_faehigkeit"
 
 msgid "rules.vision_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Seh-Fähigkeit"
 
-msgid "rules.workload_label"
-msgstr ""
-
-msgid "rules.workload_explanation"
-msgstr ""
-
-msgid "rules.xenophobia_label"
-msgstr "Xenophobie/Fremdenfeindlichkeit"
+msgid "rules.xenophobia_anchor"
+msgstr "xenophobie/fremdenfeindlichkeit"
 
 msgid "rules.xenophobia_explanation"
 msgstr "Fremdenfeindlich, xenophob"

--- a/locales/de_DE/LC_MESSAGES/messages.po
+++ b/locales/de_DE/LC_MESSAGES/messages.po
@@ -3,448 +3,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: engineering@witty.works\n"
-"POT-Creation-Date: 2022-09-13 14:30\n"
-"PO-Revision-Date: 2022-09-13 14:30\n"
+"POT-Creation-Date: 2022-09-19 13:51\n"
+"PO-Revision-Date: 2022-09-19 13:51\n"
 "Last-Translator: engineering@witty.works\n"
 "Language-Team: engineering@witty.works\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "rules.abbreviation_label"
-msgstr "Abkürzung"
+msgid "rules.abbreviation_anchor"
+msgstr "abkuerzung"
 
 msgid "rules.abbreviation_explanation"
 msgstr "Sicher, dass das Lesende verstehen?"
 
-msgid "rules.ability_label"
-msgstr "Fähigkeiten"
+msgid "rules.ability_anchor"
+msgstr "faehigkeiten"
 
 msgid "rules.ability_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Behinderungen"
 
-msgid "rules.ableism_label"
-msgstr "Behindertenfeindlichkeit"
+msgid "rules.ableism_anchor"
+msgstr "behindertenfeindlichkeit"
 
 msgid "rules.ableism_explanation"
 msgstr "Feindlich gegenüber Menschen mit Behinderung"
 
-msgid "rules.age_label"
-msgstr "Altersangabe"
+msgid "rules.age_anchor"
+msgstr "altersangabe"
 
 msgid "rules.age_explanation"
 msgstr "Sicher, dass du das Alter wissen musst?"
 
-msgid "rules.age_in_jobs_label"
-msgstr ""
-
-msgid "rules.age_in_jobs_explanation"
-msgstr ""
-
-msgid "rules.age_old_label"
-msgstr "50 Jahre und älter"
+msgid "rules.age_old_anchor"
+msgstr "50_jahre_und_aelter"
 
 msgid "rules.age_old_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Alter 50+"
 
-msgid "rules.age_young_label"
-msgstr "25 Jahre und jünger"
+msgid "rules.age_young_anchor"
+msgstr "25_jahre_und_juenger"
 
 msgid "rules.age_young_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Alter unter 25"
 
-msgid "rules.agentic_label"
-msgstr "Agentisch"
+msgid "rules.ageism_anchor"
+msgstr "altersdiskriminierungen"
+
+msgid "rules.ageism_explanation"
+msgstr ""
+
+msgid "rules.agentic_anchor"
+msgstr "agentisch"
 
 msgid "rules.agentic_explanation"
 msgstr "Fühlt sich weder kooperativ noch unterstützend an"
 
-msgid "rules.anglicism_label"
-msgstr "Anglizismen"
+msgid "rules.anglicism_anchor"
+msgstr "anglizismen"
 
 msgid "rules.anglicism_explanation"
 msgstr "Anglizismen: Sicher, dass das alle Lesenden verstehen?"
 
-msgid "rules.antimuslim_label"
-msgstr "Islamophobie"
+msgid "rules.antimuslim_anchor"
+msgstr "islamophobie"
 
 msgid "rules.antimuslim_explanation"
 msgstr "Islamophob"
 
-msgid "rules.antisemitism_label"
-msgstr "Anti-Semitismus"
+msgid "rules.antisemitism_anchor"
+msgstr "anti-semitismus"
 
 msgid "rules.antisemitism_explanation"
 msgstr "Anti-semitisch"
 
-msgid "rules.behavior_label"
-msgstr "Verhalten"
+msgid "rules.behavior_anchor"
+msgstr "verhalten"
 
 msgid "rules.behavior_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Verhalten"
 
-msgid "rules.belief_label"
-msgstr "Glauben"
+msgid "rules.belief_anchor"
+msgstr "glauben"
 
 msgid "rules.belief_explanation"
 msgstr "Glauben ausdrückend; stimmt nicht für alle"
 
-msgid "rules.binary_pronouns_label"
-msgstr "Binäre Pronomen"
+msgid "rules.binary_pronouns_anchor"
+msgstr "binaere_pronomen"
 
 msgid "rules.binary_pronouns_explanation"
 msgstr "Pronomen gemäss binärem Geschlechterverständnis"
 
-msgid "rules.caring_label"
-msgstr "Einfühlsam"
+msgid "rules.caring_anchor"
+msgstr "einfühlsam"
 
 msgid "rules.caring_explanation"
 msgstr "Betont Offenheit, Fürsorge und Interesse"
 
-msgid "rules.classism_label"
-msgstr "Klassismus"
+msgid "rules.classism_anchor"
+msgstr "klassismus"
 
 msgid "rules.classism_explanation"
 msgstr "Drückt Machtungleichgewicht aus"
 
-msgid "rules.cognitive_ability_label"
-msgstr "Denkfähigkeit"
+msgid "rules.cognitive_ability_anchor"
+msgstr "denkfaehigkeit"
 
 msgid "rules.cognitive_ability_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Lernfähigkeit"
 
-msgid "rules.cognitive_perception_label"
-msgstr "Wahrnehmung"
+msgid "rules.cognitive_perception_anchor"
+msgstr "wahrnehmung"
 
 msgid "rules.cognitive_perception_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich kognitiver Wahrnehmung"
 
-msgid "rules.communal_label"
-msgstr "Kommunal"
+msgid "rules.communal_anchor"
+msgstr "kommunal"
 
 msgid "rules.communal_explanation"
 msgstr "Betont kooperative Eigenschaften"
 
-msgid "rules.corporate_rules_label"
-msgstr "Organisations-Leitlinie"
+msgid "rules.corporate_rules_anchor"
+msgstr "organisations_leitlinie"
 
 msgid "rules.corporate_rules_explanation"
 msgstr "Wir schreiben lieber"
 
-msgid "rules.culture_label"
-msgstr "Kultur"
+msgid "rules.culture_anchor"
+msgstr "kultur"
 
 msgid "rules.culture_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich kulturellem Hintergrund"
 
-msgid "rules.d_and_i_label"
-msgstr "Diversität & Inklusion"
+msgid "rules.d_and_i_anchor"
+msgstr "diversitaet_&_inklusion"
 
 msgid "rules.d_and_i_explanation"
 msgstr "Bestärkt Wert von Diversity, Gleichstellung und Inklusion"
 
-msgid "rules.education_label"
-msgstr ""
-
-msgid "rules.education_explanation"
-msgstr ""
-
-msgid "rules.emotional_security_label"
+msgid "rules.emotional_security_anchor"
 msgstr ""
 
 msgid "rules.emotional_security_explanation"
 msgstr "Vermittelt emotionale Sicherheit"
 
-msgid "rules.ethnicity_label"
-msgstr ""
-
-msgid "rules.ethnicity_explanation"
-msgstr ""
-
-msgid "rules.exaggerating_label"
-msgstr "Superlative"
+msgid "rules.exaggerating_anchor"
+msgstr "superlative"
 
 msgid "rules.exaggerating_explanation"
 msgstr "Superlative: als Druck oder Arroganz wahrgenommen"
 
-msgid "rules.female_stereotype_label"
-msgstr "Weiblicher Stereotyp"
+msgid "rules.female_stereotype_anchor"
+msgstr "weiblicher_stereotyp"
 
 msgid "rules.female_stereotype_explanation"
 msgstr "Steckt Frauen in traditionelle Rollen"
 
-msgid "rules.filler_label"
-msgstr "Füllwörter"
+msgid "rules.filler_anchor"
+msgstr "fuellwoerter"
 
 msgid "rules.filler_explanation"
 msgstr "Füllwörter machen das Verständnis schwieriger"
 
-msgid "rules.formality_label"
-msgstr "Formalität"
+msgid "rules.formality_anchor"
+msgstr "formalitaet"
 
 msgid "rules.formality_explanation"
 msgstr "Formale Formulierung kreiert emotionale Distanz"
 
-msgid "rules.function_label"
-msgstr "Spezielle Funktionen"
+msgid "rules.function_anchor"
+msgstr "spezielle_funktionen"
 
 msgid "rules.function_explanation"
 msgstr "Bild eines Mannes wird unbewusst ausgelöst"
 
-msgid "rules.gen_boomer_label"
-msgstr "Sprache Generation Boomer & X"
+msgid "rules.gen_boomer_anchor"
+msgstr "sprach_generation_boomer_&_X"
 
 msgid "rules.gen_boomer_explanation"
 msgstr "Selten bekannte Formulierung der Generation Boomer"
 
-msgid "rules.gen_z_label"
-msgstr "Gen Z Language"
+msgid "rules.gen_z_anchor"
+msgstr "gen_z_sprache"
 
 msgid "rules.gen_z_explanation"
 msgstr "Nicht allen bekannte Formulierung der Generation Z"
 
-msgid "rules.gender_identity_label"
-msgstr "Geschlechtsidentität"
+msgid "rules.gender_identity_anchor"
+msgstr "geschlechtsidentitaet"
 
 msgid "rules.gender_identity_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Geschlechtsidentität"
 
-msgid "rules.gendered_label"
-msgstr "Geschlechtsspezifisch"
+msgid "rules.gendered_anchor"
+msgstr "geschlechtsspezifisch"
 
 msgid "rules.gendered_explanation"
 msgstr "Schubladendenken nach Geschlechternormen"
 
-msgid "rules.gendered_denominations_ending_label"
-msgstr "Inklusive Endung"
+msgid "rules.gendered_denominations_ending_anchor"
+msgstr "inklusive_endung"
 
 msgid "rules.gendered_denominations_ending_explanation"
 msgstr "Nicht konsistente Geschlechts-Schreibweise"
 
-msgid "rules.generic_plural_label"
-msgstr "Generisches Plural"
+msgid "rules.generic_plural_anchor"
+msgstr "generisches_plural"
 
 msgid "rules.generic_plural_explanation"
 msgstr "Geschlechtsspezifisches Bild stark verankert. Im Plural weniger."
 
-msgid "rules.hearing_label"
-msgstr "Hör-Fähigkeit"
+msgid "rules.hearing_anchor"
+msgstr "hoer_faehigkeit"
 
 msgid "rules.hearing_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Hör-Fähigkeit"
 
-msgid "rules.hidden_image_label"
-msgstr "Versteckter Ausdruck"
+msgid "rules.hidden_image_anchor"
+msgstr "versteckter_ausdruck"
 
 msgid "rules.hidden_image_explanation"
 msgstr "Verstecktes männliches Generikum"
 
-msgid "rules.hollow_label"
-msgstr "Worthülsen"
+msgid "rules.hollow_anchor"
+msgstr "worthuelsen"
 
 msgid "rules.hollow_explanation"
 msgstr "Worthülsen haben ihre Bedeutung verloren"
 
-msgid "rules.homophobia_label"
-msgstr "Homophobie"
+msgid "rules.homophobia_anchor"
+msgstr "homophobie"
 
 msgid "rules.homophobia_explanation"
 msgstr "Homophob"
 
-msgid "rules.inclusive_label"
-msgstr "Inklusiv"
+msgid "rules.inclusive_anchor"
+msgstr "inklusiv"
 
 msgid "rules.inclusive_explanation"
 msgstr "Lässt Zugehörigkeitsgefühl entstehen"
 
-msgid "rules.job_requirements_label"
-msgstr "Voreingenommene Anforderungen"
+msgid "rules.job_requirements_anchor"
+msgstr "voreingenommene_anforderungen"
 
 msgid "rules.job_requirements_explanation"
 msgstr ""
 
-msgid "rules.leadership_label"
-msgstr "Führungsstereotyp"
+msgid "rules.leadership_anchor"
+msgstr "fuehrungsstereotyp"
 
 msgid "rules.leadership_explanation"
 msgstr "Traditionelles Führungs-Vokabular"
 
-msgid "rules.learning_label"
-msgstr "Lernfähigkeit"
+msgid "rules.learning_anchor"
+msgstr "lernfaehigkeit"
 
 msgid "rules.learning_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Lernfähigkeit"
 
-msgid "rules.male_stereotype_label"
-msgstr "Männlicher Stereotyp"
+msgid "rules.male_stereotype_anchor"
+msgstr "maennlicher_stereotyp"
 
 msgid "rules.male_stereotype_explanation"
 msgstr "Steckt Männer in traditionelle Rollen"
 
-msgid "rules.medical_state_label"
-msgstr "Gesundheitsbild"
+msgid "rules.medical_state_anchor"
+msgstr "gesundheitsbild"
 
 msgid "rules.medical_state_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Gesundheitsbild"
 
-msgid "rules.mental_wellbeing_label"
-msgstr "Mentales Wohlbefinden"
+msgid "rules.mental_wellbeing_anchor"
+msgstr "mentales_wohlbefinden"
 
 msgid "rules.mental_wellbeing_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich mentalem Wohlbefinden"
 
-msgid "rules.migration_label"
-msgstr "Migrationshintergrund"
+msgid "rules.migration_anchor"
+msgstr "migrationshintergrund"
 
 msgid "rules.migration_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Migrationshintergrund"
 
-msgid "rules.military_source_label"
-msgstr "Militärische Wurzel"
+msgid "rules.military_source_anchor"
+msgstr "militaerische_wurzel"
 
 msgid "rules.military_source_explanation"
 msgstr "Militärischer Begriff kommuniziert kriegsähnlichen Zustand"
 
-msgid "rules.misgendering_institutions_label"
-msgstr "Geschlecht von Institutionen"
+msgid "rules.misgendering_institutions_anchor"
+msgstr "geschlecht_von_institutionen"
 
 msgid "rules.misgendering_institutions_explanation"
 msgstr "Falsche Verwendung des grammatikalischen Geschlechtes"
 
-msgid "rules.mobility_label"
-msgstr "Mobilität"
+msgid "rules.mobility_anchor"
+msgstr "mobilitaet"
 
 msgid "rules.mobility_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Mobilität"
 
-msgid "rules.offensive_language_label"
-msgstr "Beleidigende und einschüchternde Sprache"
+msgid "rules.offensive_language_anchor"
+msgstr "beleidigende_und_einschuechternde_sprache"
 
 msgid "rules.offensive_language_explanation"
 msgstr " Verletzt und schüchtert ein"
 
-msgid "rules.openly_discriminating_label"
-msgstr "Offene Diskriminierung"
+msgid "rules.openly_discriminating_anchor"
+msgstr "offene_diskriminierung"
 
 msgid "rules.openly_discriminating_explanation"
 msgstr ""
 
-msgid "rules.orthography_label"
-msgstr "Orthographie"
+msgid "rules.orthography_anchor"
+msgstr "orthographie"
 
 msgid "rules.orthography_explanation"
 msgstr "Orthographie"
 
-msgid "rules.overload_label"
-msgstr ""
-
-msgid "rules.overload_explanation"
-msgstr ""
-
-msgid "rules.passive_voice_label"
-msgstr "Passiv-Form"
+msgid "rules.passive_voice_anchor"
+msgstr "passiv_form"
 
 msgid "rules.passive_voice_explanation"
 msgstr "Durch Passiv-Form entsteht emotionale Distanz"
 
-msgid "rules.pressure_label"
-msgstr "Druck"
+msgid "rules.pressure_anchor"
+msgstr "druck"
 
 msgid "rules.pressure_explanation"
 msgstr "Kommuniziert Druck"
 
-msgid "rules.racism_label"
-msgstr "Rassismus"
+msgid "rules.racism_anchor"
+msgstr "rassismus"
 
 msgid "rules.racism_explanation"
 msgstr "Rassistisch"
 
-msgid "rules.racist_source_label"
-msgstr "Rassistische Wurzel"
+msgid "rules.racist_source_anchor"
+msgstr "rassistische_wurzel"
 
 msgid "rules.racist_source_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Hautfarbe"
 
-msgid "rules.salary_vague_label"
-msgstr ""
-
-msgid "rules.salary_vague_explanation"
-msgstr ""
-
-msgid "rules.sexism_label"
-msgstr "Sexismus"
+msgid "rules.sexism_anchor"
+msgstr "sexismus"
 
 msgid "rules.sexism_explanation"
 msgstr "Frauenfeindlich"
 
-msgid "rules.sexual_orientation_label"
-msgstr "Sexuelle Orientierung"
+msgid "rules.sexual_orientation_anchor"
+msgstr "sexuelle_orientierung"
 
 msgid "rules.sexual_orientation_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich sexueller Orientierung"
 
-msgid "rules.speech_label"
-msgstr "Sprech-Fähigkeit"
+msgid "rules.speech_anchor"
+msgstr "sprech_faehigkeit"
 
 msgid "rules.speech_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Sprech-Fähigkeit"
 
-msgid "rules.sports_terms_label"
-msgstr "Sport-Jargon"
+msgid "rules.sports_terms_anchor"
+msgstr "sport_jargon"
 
 msgid "rules.sports_terms_explanation"
 msgstr "Sportlicher Begriff drückt Wettbewerbsstimmung aus"
 
-msgid "rules.style_label"
-msgstr "Stil"
+msgid "rules.style_anchor"
+msgstr "stil"
 
 msgid "rules.style_explanation"
 msgstr ""
 
-msgid "rules.technical_frameworks_label"
-msgstr ""
-
-msgid "rules.technical_frameworks_explanation"
-msgstr ""
-
-msgid "rules.titles_label"
-msgstr "Titel"
+msgid "rules.titles_anchor"
+msgstr "titel"
 
 msgid "rules.titles_explanation"
 msgstr "“Mitmeinen” mit männlichen Generikum funktioniert nicht"
 
-msgid "rules.transphobia_label"
-msgstr "Transphobie"
+msgid "rules.transphobia_anchor"
+msgstr "transphobie"
 
 msgid "rules.transphobia_explanation"
 msgstr "Transphob"
 
-msgid "rules.unconscious_bias_label"
-msgstr "Sprachliche Voreingenommenheit"
+msgid "rules.unconscious_bias_anchor"
+msgstr "sprachliche_voreingenommenheit"
 
 msgid "rules.unconscious_bias_explanation"
 msgstr "Wort, das eine Voreingenommenheit kommuniziert, auf versteckte Art"
 
-msgid "rules.verbose_label"
-msgstr ""
-
-msgid "rules.verbose_explanation"
-msgstr "Durch ‘Nominalistil’ entsteht Distanz"
-
-msgid "rules.vision_label"
-msgstr "Seh-Fähigkeit"
+msgid "rules.vision_anchor"
+msgstr "seh_faehigkeit"
 
 msgid "rules.vision_explanation"
 msgstr "Versteckte Voreingenommenheit bezüglich Seh-Fähigkeit"
 
-msgid "rules.workload_label"
-msgstr ""
-
-msgid "rules.workload_explanation"
-msgstr ""
-
-msgid "rules.xenophobia_label"
-msgstr "Xenophobie/Fremdenfeindlichkeit"
+msgid "rules.xenophobia_anchor"
+msgstr "xenophobie/fremdenfeindlichkeit"
 
 msgid "rules.xenophobia_explanation"
 msgstr "Fremdenfeindlich, xenophob"

--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -3,448 +3,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: engineering@witty.works\n"
-"POT-Creation-Date: 2022-09-13 14:30\n"
-"PO-Revision-Date: 2022-09-13 14:30\n"
+"POT-Creation-Date: 2022-09-19 13:51\n"
+"PO-Revision-Date: 2022-09-19 13:51\n"
 "Last-Translator: engineering@witty.works\n"
 "Language-Team: engineering@witty.works\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "rules.abbreviation_label"
-msgstr "Abbreviation"
+msgid "rules.abbreviation_anchor"
+msgstr "abbreviation"
 
 msgid "rules.abbreviation_explanation"
 msgstr "Sure your readers understand?"
 
-msgid "rules.ability_label"
-msgstr "Ability"
+msgid "rules.ability_anchor"
+msgstr "ability"
 
 msgid "rules.ability_explanation"
 msgstr "Hidden bias regarding disabilities"
 
-msgid "rules.ableism_label"
-msgstr "Ableist"
+msgid "rules.ableism_anchor"
+msgstr "ableist"
 
 msgid "rules.ableism_explanation"
 msgstr "Ableist"
 
-msgid "rules.age_label"
-msgstr "Age information"
+msgid "rules.age_anchor"
+msgstr "age_information"
 
 msgid "rules.age_explanation"
 msgstr "Sure you need to ask for age?"
 
-msgid "rules.age_in_jobs_label"
-msgstr ""
-
-msgid "rules.age_in_jobs_explanation"
-msgstr ""
-
-msgid "rules.age_old_label"
-msgstr "50 years and older"
+msgid "rules.age_old_anchor"
+msgstr "50_years_and_older"
 
 msgid "rules.age_old_explanation"
 msgstr "Hidden bias regarding age over 50"
 
-msgid "rules.age_young_label"
-msgstr "25 years and younger"
+msgid "rules.age_young_anchor"
+msgstr "25_years_and_younger"
 
 msgid "rules.age_young_explanation"
 msgstr "Hidden bias regarding age below 25"
 
-msgid "rules.agentic_label"
-msgstr "Agentic"
+msgid "rules.ageism_anchor"
+msgstr "ageism"
+
+msgid "rules.ageism_explanation"
+msgstr ""
+
+msgid "rules.agentic_anchor"
+msgstr "agentic"
 
 msgid "rules.agentic_explanation"
 msgstr "Doesn’t feel cooperative nor supportive"
 
-msgid "rules.anglicism_label"
-msgstr "Anglicism"
+msgid "rules.anglicism_anchor"
+msgstr "anglicism"
 
 msgid "rules.anglicism_explanation"
 msgstr "Anglicism: Are you sure, everyone understands what you mean?"
 
-msgid "rules.antimuslim_label"
-msgstr "Islamophobia"
+msgid "rules.antimuslim_anchor"
+msgstr "islamophobia"
 
 msgid "rules.antimuslim_explanation"
 msgstr "Islamophobic"
 
-msgid "rules.antisemitism_label"
-msgstr "Anti-Semitism"
+msgid "rules.antisemitism_anchor"
+msgstr "anti-semitism"
 
 msgid "rules.antisemitism_explanation"
 msgstr "Anti-semitic"
 
-msgid "rules.behavior_label"
-msgstr "Behaviour"
+msgid "rules.behavior_anchor"
+msgstr "behaviour"
 
 msgid "rules.behavior_explanation"
 msgstr "Hidden bias regarding behaviour"
 
-msgid "rules.belief_label"
-msgstr "Belief"
+msgid "rules.belief_anchor"
+msgstr "belief"
 
 msgid "rules.belief_explanation"
 msgstr "Expressing belief; not true for all"
 
-msgid "rules.binary_pronouns_label"
-msgstr "Binary Pronouns"
+msgid "rules.binary_pronouns_anchor"
+msgstr "binary_pronouns"
 
 msgid "rules.binary_pronouns_explanation"
 msgstr "Pronouns according to binary understanding of gender"
 
-msgid "rules.caring_label"
-msgstr "Caring"
+msgid "rules.caring_anchor"
+msgstr "caring"
 
 msgid "rules.caring_explanation"
 msgstr "Emphasises the human capacity to care"
 
-msgid "rules.classism_label"
-msgstr "Classism"
+msgid "rules.classism_anchor"
+msgstr "classism"
 
 msgid "rules.classism_explanation"
 msgstr "Expresses power-imbalance"
 
-msgid "rules.cognitive_ability_label"
-msgstr "Cognitive ability"
+msgid "rules.cognitive_ability_anchor"
+msgstr "cognitive_ability"
 
 msgid "rules.cognitive_ability_explanation"
 msgstr "Hidden bias regarding cognitive ability"
 
-msgid "rules.cognitive_perception_label"
-msgstr "Cognitive perception"
+msgid "rules.cognitive_perception_anchor"
+msgstr "cognitive_perception"
 
 msgid "rules.cognitive_perception_explanation"
 msgstr "Hidden bias regarding cognitive perception"
 
-msgid "rules.communal_label"
-msgstr "Communal"
+msgid "rules.communal_anchor"
+msgstr "communal"
 
 msgid "rules.communal_explanation"
 msgstr "Emphasises cooperative attributes"
 
-msgid "rules.corporate_rules_label"
-msgstr "Organisation guideline"
+msgid "rules.corporate_rules_anchor"
+msgstr "organisation_guideline"
 
 msgid "rules.corporate_rules_explanation"
 msgstr "We prefer to write as follows"
 
-msgid "rules.culture_label"
-msgstr "Culture"
+msgid "rules.culture_anchor"
+msgstr "culture"
 
 msgid "rules.culture_explanation"
 msgstr "Hidden bias regarding cultural background"
 
-msgid "rules.d_and_i_label"
-msgstr "Diversity & Inclusion"
+msgid "rules.d_and_i_anchor"
+msgstr "diversity_&_inclusion"
 
 msgid "rules.d_and_i_explanation"
 msgstr "Emphasises value of diversity, equity and inclusion"
 
-msgid "rules.education_label"
-msgstr ""
-
-msgid "rules.education_explanation"
-msgstr ""
-
-msgid "rules.emotional_security_label"
-msgstr "Positive_emotions"
+msgid "rules.emotional_security_anchor"
+msgstr "positive_emotions"
 
 msgid "rules.emotional_security_explanation"
 msgstr ""
 
-msgid "rules.ethnicity_label"
-msgstr ""
-
-msgid "rules.ethnicity_explanation"
-msgstr ""
-
-msgid "rules.exaggerating_label"
-msgstr "Exaggeration"
+msgid "rules.exaggerating_anchor"
+msgstr "exaggeration"
 
 msgid "rules.exaggerating_explanation"
 msgstr "Exaggeration: Perceived as pressure or arrogance"
 
-msgid "rules.female_stereotype_label"
-msgstr "Female Stereotype"
+msgid "rules.female_stereotype_anchor"
+msgstr "female_stereotype"
 
 msgid "rules.female_stereotype_explanation"
 msgstr "Branding women in traditional roles"
 
-msgid "rules.filler_label"
-msgstr "Filler Words"
+msgid "rules.filler_anchor"
+msgstr "filler_words"
 
 msgid "rules.filler_explanation"
 msgstr "Filler words make understanding harder"
 
-msgid "rules.formality_label"
-msgstr "Formality"
+msgid "rules.formality_anchor"
+msgstr "formality"
 
 msgid "rules.formality_explanation"
 msgstr "Formal wording creates emotional distance"
 
-msgid "rules.function_label"
-msgstr "Special functions"
+msgid "rules.function_anchor"
+msgstr "special_functions"
 
 msgid "rules.function_explanation"
 msgstr "Image of a man unconsciously triggered"
 
-msgid "rules.gen_boomer_label"
-msgstr "Language Generation Boomer & X"
+msgid "rules.gen_boomer_anchor"
+msgstr "language_generation_boomer_&_X"
 
 msgid "rules.gen_boomer_explanation"
 msgstr "Seldom known wording of generation boomer"
 
-msgid "rules.gen_z_label"
-msgstr "Gen Z Language"
+msgid "rules.gen_z_anchor"
+msgstr "gen_z_language"
 
 msgid "rules.gen_z_explanation"
 msgstr "Wording of generation Z not known to all"
 
-msgid "rules.gender_identity_label"
-msgstr "Gender identity"
+msgid "rules.gender_identity_anchor"
+msgstr "gender_identity"
 
 msgid "rules.gender_identity_explanation"
 msgstr "Hidden bias regarding gender identity"
 
-msgid "rules.gendered_label"
-msgstr "Gendered"
+msgid "rules.gendered_anchor"
+msgstr "gendered"
 
 msgid "rules.gendered_explanation"
 msgstr "Getting stuck in gender normatives"
 
-msgid "rules.gendered_denominations_ending_label"
-msgstr "Inclusive ending"
+msgid "rules.gendered_denominations_ending_anchor"
+msgstr "inclusive_ending"
 
 msgid "rules.gendered_denominations_ending_explanation"
 msgstr "Non-consistent gender-ending"
 
-msgid "rules.generic_plural_label"
-msgstr "Generic plural"
+msgid "rules.generic_plural_anchor"
+msgstr "generic_plural"
 
 msgid "rules.generic_plural_explanation"
 msgstr "Gendered image deeply anchored. In plural less."
 
-msgid "rules.hearing_label"
-msgstr "Hearing"
+msgid "rules.hearing_anchor"
+msgstr "hearing"
 
 msgid "rules.hearing_explanation"
 msgstr "Hidden bias regarding hearing ability"
 
-msgid "rules.hidden_image_label"
-msgstr "Hidden meaning"
+msgid "rules.hidden_image_anchor"
+msgstr "hidden_meaning"
 
 msgid "rules.hidden_image_explanation"
 msgstr "Hidden male generic"
 
-msgid "rules.hollow_label"
-msgstr "Empty Words"
+msgid "rules.hollow_anchor"
+msgstr "empty_words"
 
 msgid "rules.hollow_explanation"
 msgstr "Empty words have lost all meaning"
 
-msgid "rules.homophobia_label"
-msgstr "Homophobia"
+msgid "rules.homophobia_anchor"
+msgstr "homophobia"
 
 msgid "rules.homophobia_explanation"
 msgstr "Homophobe"
 
-msgid "rules.inclusive_label"
-msgstr "Inclusive"
+msgid "rules.inclusive_anchor"
+msgstr "inclusive"
 
 msgid "rules.inclusive_explanation"
 msgstr "Creates sense of belonging"
 
-msgid "rules.job_requirements_label"
-msgstr "Biased Requirements"
+msgid "rules.job_requirements_anchor"
+msgstr "biased_requirements"
 
 msgid "rules.job_requirements_explanation"
 msgstr ""
 
-msgid "rules.leadership_label"
-msgstr "Leadership stereotype"
+msgid "rules.leadership_anchor"
+msgstr "leadership_stereotype"
 
 msgid "rules.leadership_explanation"
 msgstr "Traditional leadership vocabulary"
 
-msgid "rules.learning_label"
-msgstr "Learning ability"
+msgid "rules.learning_anchor"
+msgstr "learning_ability"
 
 msgid "rules.learning_explanation"
 msgstr "Hidden bias regarding learning ability"
 
-msgid "rules.male_stereotype_label"
-msgstr "Male Stereotype"
+msgid "rules.male_stereotype_anchor"
+msgstr "male_stereotype"
 
 msgid "rules.male_stereotype_explanation"
 msgstr "Branding men in traditional roles"
 
-msgid "rules.medical_state_label"
-msgstr "Medical state"
+msgid "rules.medical_state_anchor"
+msgstr "medical_state"
 
 msgid "rules.medical_state_explanation"
 msgstr "Hidden bias regarding medical state"
 
-msgid "rules.mental_wellbeing_label"
-msgstr "Mental wellbeing"
+msgid "rules.mental_wellbeing_anchor"
+msgstr "mental_wellbeing"
 
 msgid "rules.mental_wellbeing_explanation"
 msgstr "Hidden bias regarding mental wellbeing"
 
-msgid "rules.migration_label"
-msgstr "Migration background"
+msgid "rules.migration_anchor"
+msgstr "migration_background"
 
 msgid "rules.migration_explanation"
 msgstr "Hidden bias regarding migration background"
 
-msgid "rules.military_source_label"
-msgstr "Military source"
+msgid "rules.military_source_anchor"
+msgstr "military_source"
 
 msgid "rules.military_source_explanation"
 msgstr "Military term expressing war-like ambiance"
 
-msgid "rules.misgendering_institutions_label"
-msgstr ""
+msgid "rules.misgendering_institutions_anchor"
+msgstr "gendering_of_institutions"
 
 msgid "rules.misgendering_institutions_explanation"
 msgstr ""
 
-msgid "rules.mobility_label"
-msgstr "Mobility"
+msgid "rules.mobility_anchor"
+msgstr "mobility"
 
 msgid "rules.mobility_explanation"
 msgstr "Hidden bias regarding mobility"
 
-msgid "rules.offensive_language_label"
-msgstr "Offensive language"
+msgid "rules.offensive_language_anchor"
+msgstr "offensive_language"
 
 msgid "rules.offensive_language_explanation"
 msgstr "Offends and intimidates"
 
-msgid "rules.openly_discriminating_label"
-msgstr "Openly discriminating"
+msgid "rules.openly_discriminating_anchor"
+msgstr "openly_discriminating"
 
 msgid "rules.openly_discriminating_explanation"
 msgstr ""
 
-msgid "rules.orthography_label"
-msgstr "Orthography"
+msgid "rules.orthography_anchor"
+msgstr "orthography"
 
 msgid "rules.orthography_explanation"
 msgstr "Orthography"
 
-msgid "rules.overload_label"
-msgstr ""
-
-msgid "rules.overload_explanation"
-msgstr ""
-
-msgid "rules.passive_voice_label"
-msgstr "Passive Voice"
+msgid "rules.passive_voice_anchor"
+msgstr "passive_voice"
 
 msgid "rules.passive_voice_explanation"
 msgstr "Passive voice creates emotional distance"
 
-msgid "rules.pressure_label"
-msgstr "Pressure"
+msgid "rules.pressure_anchor"
+msgstr "pressure"
 
 msgid "rules.pressure_explanation"
 msgstr "Expresses pressure"
 
-msgid "rules.racism_label"
-msgstr "Racism"
+msgid "rules.racism_anchor"
+msgstr "racism"
 
 msgid "rules.racism_explanation"
 msgstr "Racist"
 
-msgid "rules.racist_source_label"
-msgstr "Racist source"
+msgid "rules.racist_source_anchor"
+msgstr "racist_source"
 
 msgid "rules.racist_source_explanation"
 msgstr "Hidden bias regarding skin colour"
 
-msgid "rules.salary_vague_label"
-msgstr ""
-
-msgid "rules.salary_vague_explanation"
-msgstr ""
-
-msgid "rules.sexism_label"
-msgstr "Sexism"
+msgid "rules.sexism_anchor"
+msgstr "sexism"
 
 msgid "rules.sexism_explanation"
 msgstr "Mysogynist"
 
-msgid "rules.sexual_orientation_label"
-msgstr "Sexual orientation"
+msgid "rules.sexual_orientation_anchor"
+msgstr "sexual_orientation"
 
 msgid "rules.sexual_orientation_explanation"
 msgstr "Hidden bias regarding sexual orientation"
 
-msgid "rules.speech_label"
-msgstr "Speech ability"
+msgid "rules.speech_anchor"
+msgstr "speech_ability"
 
 msgid "rules.speech_explanation"
 msgstr "Hidden bias regarding speech ability"
 
-msgid "rules.sports_terms_label"
-msgstr "Sports terms"
+msgid "rules.sports_terms_anchor"
+msgstr "sports_terms"
 
 msgid "rules.sports_terms_explanation"
 msgstr "Sports term expresses competitive ambiance"
 
-msgid "rules.style_label"
-msgstr "Style"
+msgid "rules.style_anchor"
+msgstr "style"
 
 msgid "rules.style_explanation"
 msgstr ""
 
-msgid "rules.technical_frameworks_label"
-msgstr ""
-
-msgid "rules.technical_frameworks_explanation"
-msgstr ""
-
-msgid "rules.titles_label"
-msgstr "Titles"
+msgid "rules.titles_anchor"
+msgstr "titles"
 
 msgid "rules.titles_explanation"
 msgstr "Male generic doesn’t address all genders"
 
-msgid "rules.transphobia_label"
-msgstr "Transphobia"
+msgid "rules.transphobia_anchor"
+msgstr "transphobia"
 
 msgid "rules.transphobia_explanation"
 msgstr "Transphobic"
 
-msgid "rules.unconscious_bias_label"
-msgstr "Biased language"
+msgid "rules.unconscious_bias_anchor"
+msgstr "biased_language"
 
 msgid "rules.unconscious_bias_explanation"
 msgstr "Word communicating bias, in a hidden way"
 
-msgid "rules.verbose_label"
-msgstr ""
-
-msgid "rules.verbose_explanation"
-msgstr ""
-
-msgid "rules.vision_label"
-msgstr "Vision"
+msgid "rules.vision_anchor"
+msgstr "vision"
 
 msgid "rules.vision_explanation"
 msgstr "Hidden bias regarding vision ability"
 
-msgid "rules.workload_label"
-msgstr ""
-
-msgid "rules.workload_explanation"
-msgstr ""
-
-msgid "rules.xenophobia_label"
-msgstr "Xenophobia"
+msgid "rules.xenophobia_anchor"
+msgstr "xenophobia"
 
 msgid "rules.xenophobia_explanation"
 msgstr "Xenophobic"

--- a/locales/en_US/LC_MESSAGES/messages.po
+++ b/locales/en_US/LC_MESSAGES/messages.po
@@ -3,448 +3,406 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: engineering@witty.works\n"
-"POT-Creation-Date: 2022-09-13 14:30\n"
-"PO-Revision-Date: 2022-09-13 14:30\n"
+"POT-Creation-Date: 2022-09-19 13:51\n"
+"PO-Revision-Date: 2022-09-19 13:51\n"
 "Last-Translator: engineering@witty.works\n"
 "Language-Team: engineering@witty.works\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "rules.abbreviation_label"
-msgstr "Abbreviation"
+msgid "rules.abbreviation_anchor"
+msgstr "abbreviation"
 
 msgid "rules.abbreviation_explanation"
 msgstr "Sure your readers understand?"
 
-msgid "rules.ability_label"
-msgstr "Ability"
+msgid "rules.ability_anchor"
+msgstr "ability"
 
 msgid "rules.ability_explanation"
 msgstr "Hidden bias regarding disabilities"
 
-msgid "rules.ableism_label"
-msgstr "Ableist"
+msgid "rules.ableism_anchor"
+msgstr "ableist"
 
 msgid "rules.ableism_explanation"
 msgstr "Ableist"
 
-msgid "rules.age_label"
-msgstr "Age information"
+msgid "rules.age_anchor"
+msgstr "age_information"
 
 msgid "rules.age_explanation"
 msgstr "Sure you need to ask for age?"
 
-msgid "rules.age_in_jobs_label"
-msgstr ""
-
-msgid "rules.age_in_jobs_explanation"
-msgstr ""
-
-msgid "rules.age_old_label"
-msgstr "50 years and older"
+msgid "rules.age_old_anchor"
+msgstr "50_years_and_older"
 
 msgid "rules.age_old_explanation"
 msgstr "Hidden bias regarding age over 50"
 
-msgid "rules.age_young_label"
-msgstr "25 years and younger"
+msgid "rules.age_young_anchor"
+msgstr "25_years_and_younger"
 
 msgid "rules.age_young_explanation"
 msgstr "Hidden bias regarding age below 25"
 
-msgid "rules.agentic_label"
-msgstr "Agentic"
+msgid "rules.ageism_anchor"
+msgstr "ageism"
+
+msgid "rules.ageism_explanation"
+msgstr ""
+
+msgid "rules.agentic_anchor"
+msgstr "agentic"
 
 msgid "rules.agentic_explanation"
 msgstr "Doesn’t feel cooperative nor supportive"
 
-msgid "rules.anglicism_label"
-msgstr "Anglicism"
+msgid "rules.anglicism_anchor"
+msgstr "anglicism"
 
 msgid "rules.anglicism_explanation"
 msgstr "Anglicism: Are you sure, everyone understands what you mean?"
 
-msgid "rules.antimuslim_label"
-msgstr "Islamophobia"
+msgid "rules.antimuslim_anchor"
+msgstr "islamophobia"
 
 msgid "rules.antimuslim_explanation"
 msgstr "Islamophobic"
 
-msgid "rules.antisemitism_label"
-msgstr "Anti-Semitism"
+msgid "rules.antisemitism_anchor"
+msgstr "anti-semitism"
 
 msgid "rules.antisemitism_explanation"
 msgstr "Anti-semitic"
 
-msgid "rules.behavior_label"
-msgstr "Behavior"
+msgid "rules.behavior_anchor"
+msgstr "behavior"
 
 msgid "rules.behavior_explanation"
 msgstr "Hidden bias regarding behavior"
 
-msgid "rules.belief_label"
-msgstr "Belief"
+msgid "rules.belief_anchor"
+msgstr "belief"
 
 msgid "rules.belief_explanation"
 msgstr "Expressing belief; not true for all"
 
-msgid "rules.binary_pronouns_label"
-msgstr "Binary Pronouns"
+msgid "rules.binary_pronouns_anchor"
+msgstr "binary_pronouns"
 
 msgid "rules.binary_pronouns_explanation"
 msgstr "Pronouns according to binary understanding of gender"
 
-msgid "rules.caring_label"
-msgstr "Caring"
+msgid "rules.caring_anchor"
+msgstr "caring"
 
 msgid "rules.caring_explanation"
 msgstr "Emphasizes the human capacity to care"
 
-msgid "rules.classism_label"
-msgstr "Classism"
+msgid "rules.classism_anchor"
+msgstr "classism"
 
 msgid "rules.classism_explanation"
 msgstr "Expresses power-imbalance"
 
-msgid "rules.cognitive_ability_label"
-msgstr "Cognitive ability"
+msgid "rules.cognitive_ability_anchor"
+msgstr "cognitive_ability"
 
 msgid "rules.cognitive_ability_explanation"
 msgstr "Hidden bias regarding cognitive ability"
 
-msgid "rules.cognitive_perception_label"
-msgstr "Cognitive perception"
+msgid "rules.cognitive_perception_anchor"
+msgstr "cognitive_perception"
 
 msgid "rules.cognitive_perception_explanation"
 msgstr "Hidden bias regarding cognitive perception"
 
-msgid "rules.communal_label"
-msgstr "Communal"
+msgid "rules.communal_anchor"
+msgstr "communal"
 
 msgid "rules.communal_explanation"
 msgstr "Emphasizes cooperative attributes"
 
-msgid "rules.corporate_rules_label"
-msgstr "Organization guideline"
+msgid "rules.corporate_rules_anchor"
+msgstr "organization_guideline"
 
 msgid "rules.corporate_rules_explanation"
 msgstr "We prefer to write as follows"
 
-msgid "rules.culture_label"
-msgstr "Culture"
+msgid "rules.culture_anchor"
+msgstr "culture"
 
 msgid "rules.culture_explanation"
 msgstr "Hidden bias regarding cultural background"
 
-msgid "rules.d_and_i_label"
-msgstr "Diversity & Inclusion"
+msgid "rules.d_and_i_anchor"
+msgstr "diversity_&_inclusion"
 
 msgid "rules.d_and_i_explanation"
 msgstr "Emphasizes value of diversity, equity and inclusion"
 
-msgid "rules.education_label"
-msgstr ""
-
-msgid "rules.education_explanation"
-msgstr ""
-
-msgid "rules.emotional_security_label"
-msgstr "Positive_emotions"
+msgid "rules.emotional_security_anchor"
+msgstr "positive_emotions"
 
 msgid "rules.emotional_security_explanation"
 msgstr ""
 
-msgid "rules.ethnicity_label"
-msgstr ""
-
-msgid "rules.ethnicity_explanation"
-msgstr ""
-
-msgid "rules.exaggerating_label"
-msgstr "Exaggeration"
+msgid "rules.exaggerating_anchor"
+msgstr "exaggeration"
 
 msgid "rules.exaggerating_explanation"
 msgstr "Exaggeration: Perceived as pressure or arrogance"
 
-msgid "rules.female_stereotype_label"
-msgstr "Female Stereotype"
+msgid "rules.female_stereotype_anchor"
+msgstr "female_stereotype"
 
 msgid "rules.female_stereotype_explanation"
 msgstr "Branding women in traditional roles"
 
-msgid "rules.filler_label"
-msgstr "Filler Words"
+msgid "rules.filler_anchor"
+msgstr "filler_words"
 
 msgid "rules.filler_explanation"
 msgstr "Filler words make understanding harder"
 
-msgid "rules.formality_label"
-msgstr "Formality"
+msgid "rules.formality_anchor"
+msgstr "formality"
 
 msgid "rules.formality_explanation"
 msgstr "Formal wording creates emotional distance"
 
-msgid "rules.function_label"
-msgstr "Special functions"
+msgid "rules.function_anchor"
+msgstr "special_functions"
 
 msgid "rules.function_explanation"
 msgstr "Image of a man unconsciously triggered"
 
-msgid "rules.gen_boomer_label"
-msgstr "Language Generation Boomer & X"
+msgid "rules.gen_boomer_anchor"
+msgstr "language_generation_boomer_&_X"
 
 msgid "rules.gen_boomer_explanation"
 msgstr "Seldom known wording of generation boomer"
 
-msgid "rules.gen_z_label"
-msgstr "Gen Z Language"
+msgid "rules.gen_z_anchor"
+msgstr "gen_z_language"
 
 msgid "rules.gen_z_explanation"
 msgstr "Wording of generation Z not known to all"
 
-msgid "rules.gender_identity_label"
-msgstr "Gender identity"
+msgid "rules.gender_identity_anchor"
+msgstr "gender_identity"
 
 msgid "rules.gender_identity_explanation"
 msgstr "Hidden bias regarding gender identity"
 
-msgid "rules.gendered_label"
-msgstr "Gendered"
+msgid "rules.gendered_anchor"
+msgstr "gendered"
 
 msgid "rules.gendered_explanation"
 msgstr "Getting stuck in gender normatives"
 
-msgid "rules.gendered_denominations_ending_label"
-msgstr "Inclusive ending"
+msgid "rules.gendered_denominations_ending_anchor"
+msgstr "inclusive_ending"
 
 msgid "rules.gendered_denominations_ending_explanation"
 msgstr "Non-consistent gender-ending"
 
-msgid "rules.generic_plural_label"
-msgstr "Generic plural"
+msgid "rules.generic_plural_anchor"
+msgstr "generic_plural"
 
 msgid "rules.generic_plural_explanation"
 msgstr "Gendered image deeply anchored. In plural less."
 
-msgid "rules.hearing_label"
-msgstr "Hearing"
+msgid "rules.hearing_anchor"
+msgstr "hearing"
 
 msgid "rules.hearing_explanation"
 msgstr "Hidden bias regarding hearing ability"
 
-msgid "rules.hidden_image_label"
-msgstr "Hidden meaning"
+msgid "rules.hidden_image_anchor"
+msgstr "hidden_meaning"
 
 msgid "rules.hidden_image_explanation"
 msgstr "Hidden male generic"
 
-msgid "rules.hollow_label"
-msgstr "Empty Words"
+msgid "rules.hollow_anchor"
+msgstr "empty_words"
 
 msgid "rules.hollow_explanation"
 msgstr "Empty words have lost all meaning"
 
-msgid "rules.homophobia_label"
-msgstr "Homophobia"
+msgid "rules.homophobia_anchor"
+msgstr "homophobia"
 
 msgid "rules.homophobia_explanation"
 msgstr "Homophobe"
 
-msgid "rules.inclusive_label"
-msgstr "Inclusive"
+msgid "rules.inclusive_anchor"
+msgstr "inclusive"
 
 msgid "rules.inclusive_explanation"
 msgstr "Creates sense of belonging"
 
-msgid "rules.job_requirements_label"
-msgstr "Biased Requirements"
+msgid "rules.job_requirements_anchor"
+msgstr "biased_requirements"
 
 msgid "rules.job_requirements_explanation"
 msgstr ""
 
-msgid "rules.leadership_label"
-msgstr "Leadership stereotype"
+msgid "rules.leadership_anchor"
+msgstr "leadership_stereotype"
 
 msgid "rules.leadership_explanation"
 msgstr "Traditional leadership vocabulary"
 
-msgid "rules.learning_label"
-msgstr "Learning ability"
+msgid "rules.learning_anchor"
+msgstr "learning_ability"
 
 msgid "rules.learning_explanation"
 msgstr "Hidden bias regarding learning ability"
 
-msgid "rules.male_stereotype_label"
-msgstr "Male Stereotype"
+msgid "rules.male_stereotype_anchor"
+msgstr "male_stereotype"
 
 msgid "rules.male_stereotype_explanation"
 msgstr "Branding men in traditional roles"
 
-msgid "rules.medical_state_label"
-msgstr "Medical state"
+msgid "rules.medical_state_anchor"
+msgstr "medical_state"
 
 msgid "rules.medical_state_explanation"
 msgstr "Hidden bias regarding medical state"
 
-msgid "rules.mental_wellbeing_label"
-msgstr "Mental wellbeing"
+msgid "rules.mental_wellbeing_anchor"
+msgstr "mental_wellbeing"
 
 msgid "rules.mental_wellbeing_explanation"
 msgstr "Hidden bias regarding mental wellbeing"
 
-msgid "rules.migration_label"
-msgstr "Migration background"
+msgid "rules.migration_anchor"
+msgstr "migration_background"
 
 msgid "rules.migration_explanation"
 msgstr "Hidden bias regarding migration background"
 
-msgid "rules.military_source_label"
-msgstr "Military source"
+msgid "rules.military_source_anchor"
+msgstr "military_source"
 
 msgid "rules.military_source_explanation"
 msgstr "Military term expressing war-like ambiance"
 
-msgid "rules.misgendering_institutions_label"
-msgstr ""
+msgid "rules.misgendering_institutions_anchor"
+msgstr "gendering_of_institutions"
 
 msgid "rules.misgendering_institutions_explanation"
 msgstr ""
 
-msgid "rules.mobility_label"
-msgstr "Mobility"
+msgid "rules.mobility_anchor"
+msgstr "mobility"
 
 msgid "rules.mobility_explanation"
 msgstr "Hidden bias regarding mobility"
 
-msgid "rules.offensive_language_label"
-msgstr "Offensive language"
+msgid "rules.offensive_language_anchor"
+msgstr "offensive_language"
 
 msgid "rules.offensive_language_explanation"
 msgstr "Offends and intimidates"
 
-msgid "rules.openly_discriminating_label"
-msgstr "Openly discriminating"
+msgid "rules.openly_discriminating_anchor"
+msgstr "openly_discriminating"
 
 msgid "rules.openly_discriminating_explanation"
 msgstr ""
 
-msgid "rules.orthography_label"
-msgstr "Orthography"
+msgid "rules.orthography_anchor"
+msgstr "orthography"
 
 msgid "rules.orthography_explanation"
 msgstr "Orthography"
 
-msgid "rules.overload_label"
-msgstr ""
-
-msgid "rules.overload_explanation"
-msgstr ""
-
-msgid "rules.passive_voice_label"
-msgstr "Passive Voice"
+msgid "rules.passive_voice_anchor"
+msgstr "passive_voice"
 
 msgid "rules.passive_voice_explanation"
 msgstr "Passive voice creates emotional distance"
 
-msgid "rules.pressure_label"
-msgstr "Pressure"
+msgid "rules.pressure_anchor"
+msgstr "pressure"
 
 msgid "rules.pressure_explanation"
 msgstr "Expresses pressure"
 
-msgid "rules.racism_label"
-msgstr "Racism"
+msgid "rules.racism_anchor"
+msgstr "racism"
 
 msgid "rules.racism_explanation"
 msgstr "Racist"
 
-msgid "rules.racist_source_label"
-msgstr "Racist source"
+msgid "rules.racist_source_anchor"
+msgstr "racist_source"
 
 msgid "rules.racist_source_explanation"
 msgstr "Hidden bias regarding skin color"
 
-msgid "rules.salary_vague_label"
-msgstr ""
-
-msgid "rules.salary_vague_explanation"
-msgstr ""
-
-msgid "rules.sexism_label"
-msgstr "Sexism"
+msgid "rules.sexism_anchor"
+msgstr "sexism"
 
 msgid "rules.sexism_explanation"
 msgstr "Mysogynist"
 
-msgid "rules.sexual_orientation_label"
-msgstr "Sexual orientation"
+msgid "rules.sexual_orientation_anchor"
+msgstr "sexual_orientation"
 
 msgid "rules.sexual_orientation_explanation"
 msgstr "Hidden bias regarding sexual orientation"
 
-msgid "rules.speech_label"
-msgstr "Speech ability"
+msgid "rules.speech_anchor"
+msgstr "speech_ability"
 
 msgid "rules.speech_explanation"
 msgstr "Hidden bias regarding speech ability"
 
-msgid "rules.sports_terms_label"
-msgstr "Sports terms"
+msgid "rules.sports_terms_anchor"
+msgstr "sports_terms"
 
 msgid "rules.sports_terms_explanation"
 msgstr "Sports term expresses competitive ambiance"
 
-msgid "rules.style_label"
-msgstr "Style"
+msgid "rules.style_anchor"
+msgstr "style"
 
 msgid "rules.style_explanation"
 msgstr ""
 
-msgid "rules.technical_frameworks_label"
-msgstr ""
-
-msgid "rules.technical_frameworks_explanation"
-msgstr ""
-
-msgid "rules.titles_label"
-msgstr "Titles"
+msgid "rules.titles_anchor"
+msgstr "titles"
 
 msgid "rules.titles_explanation"
 msgstr "Male generic doesn’t address all genders"
 
-msgid "rules.transphobia_label"
-msgstr "Transphobia"
+msgid "rules.transphobia_anchor"
+msgstr "transphobia"
 
 msgid "rules.transphobia_explanation"
 msgstr "Transphobic"
 
-msgid "rules.unconscious_bias_label"
-msgstr "Biased language"
+msgid "rules.unconscious_bias_anchor"
+msgstr "biased_language"
 
 msgid "rules.unconscious_bias_explanation"
 msgstr "Word communicating bias, in a hidden way"
 
-msgid "rules.verbose_label"
-msgstr ""
-
-msgid "rules.verbose_explanation"
-msgstr ""
-
-msgid "rules.vision_label"
-msgstr "Vision"
+msgid "rules.vision_anchor"
+msgstr "vision"
 
 msgid "rules.vision_explanation"
 msgstr "Hidden bias regarding vision ability"
 
-msgid "rules.workload_label"
-msgstr ""
-
-msgid "rules.workload_explanation"
-msgstr ""
-
-msgid "rules.xenophobia_label"
-msgstr "Xenophobia"
+msgid "rules.xenophobia_anchor"
+msgstr "xenophobia"
 
 msgid "rules.xenophobia_explanation"
 msgstr "Xenophobic"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -3,447 +3,405 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: engineering@witty.works\n"
-"POT-Creation-Date: 2022-09-13 14:30\n"
-"PO-Revision-Date: 2022-09-13 14:30\n"
+"POT-Creation-Date: 2022-09-19 13:51\n"
+"PO-Revision-Date: 2022-09-19 13:51\n"
 "Last-Translator: engineering@witty.works\n"
 "Language-Team: engineering@witty.works\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "rules.abbreviation_label"
+msgid "rules.abbreviation_anchor"
 msgstr ""
 
 msgid "rules.abbreviation_explanation"
 msgstr ""
 
-msgid "rules.ability_label"
+msgid "rules.ability_anchor"
 msgstr ""
 
 msgid "rules.ability_explanation"
 msgstr ""
 
-msgid "rules.ableism_label"
+msgid "rules.ableism_anchor"
 msgstr ""
 
 msgid "rules.ableism_explanation"
 msgstr ""
 
-msgid "rules.age_label"
+msgid "rules.age_anchor"
 msgstr ""
 
 msgid "rules.age_explanation"
 msgstr ""
 
-msgid "rules.age_in_jobs_label"
-msgstr ""
-
-msgid "rules.age_in_jobs_explanation"
-msgstr ""
-
-msgid "rules.age_old_label"
+msgid "rules.age_old_anchor"
 msgstr ""
 
 msgid "rules.age_old_explanation"
 msgstr ""
 
-msgid "rules.age_young_label"
+msgid "rules.age_young_anchor"
 msgstr ""
 
 msgid "rules.age_young_explanation"
 msgstr ""
 
-msgid "rules.agentic_label"
+msgid "rules.ageism_anchor"
+msgstr ""
+
+msgid "rules.ageism_explanation"
+msgstr ""
+
+msgid "rules.agentic_anchor"
 msgstr ""
 
 msgid "rules.agentic_explanation"
 msgstr ""
 
-msgid "rules.anglicism_label"
+msgid "rules.anglicism_anchor"
 msgstr ""
 
 msgid "rules.anglicism_explanation"
 msgstr ""
 
-msgid "rules.antimuslim_label"
+msgid "rules.antimuslim_anchor"
 msgstr ""
 
 msgid "rules.antimuslim_explanation"
 msgstr ""
 
-msgid "rules.antisemitism_label"
+msgid "rules.antisemitism_anchor"
 msgstr ""
 
 msgid "rules.antisemitism_explanation"
 msgstr ""
 
-msgid "rules.behavior_label"
+msgid "rules.behavior_anchor"
 msgstr ""
 
 msgid "rules.behavior_explanation"
 msgstr ""
 
-msgid "rules.belief_label"
+msgid "rules.belief_anchor"
 msgstr ""
 
 msgid "rules.belief_explanation"
 msgstr ""
 
-msgid "rules.binary_pronouns_label"
+msgid "rules.binary_pronouns_anchor"
 msgstr ""
 
 msgid "rules.binary_pronouns_explanation"
 msgstr ""
 
-msgid "rules.caring_label"
+msgid "rules.caring_anchor"
 msgstr ""
 
 msgid "rules.caring_explanation"
 msgstr ""
 
-msgid "rules.classism_label"
+msgid "rules.classism_anchor"
 msgstr ""
 
 msgid "rules.classism_explanation"
 msgstr ""
 
-msgid "rules.cognitive_ability_label"
+msgid "rules.cognitive_ability_anchor"
 msgstr ""
 
 msgid "rules.cognitive_ability_explanation"
 msgstr ""
 
-msgid "rules.cognitive_perception_label"
+msgid "rules.cognitive_perception_anchor"
 msgstr ""
 
 msgid "rules.cognitive_perception_explanation"
 msgstr ""
 
-msgid "rules.communal_label"
+msgid "rules.communal_anchor"
 msgstr ""
 
 msgid "rules.communal_explanation"
 msgstr ""
 
-msgid "rules.corporate_rules_label"
+msgid "rules.corporate_rules_anchor"
 msgstr ""
 
 msgid "rules.corporate_rules_explanation"
 msgstr ""
 
-msgid "rules.culture_label"
+msgid "rules.culture_anchor"
 msgstr ""
 
 msgid "rules.culture_explanation"
 msgstr ""
 
-msgid "rules.d_and_i_label"
+msgid "rules.d_and_i_anchor"
 msgstr ""
 
 msgid "rules.d_and_i_explanation"
 msgstr ""
 
-msgid "rules.education_label"
-msgstr ""
-
-msgid "rules.education_explanation"
-msgstr ""
-
-msgid "rules.emotional_security_label"
+msgid "rules.emotional_security_anchor"
 msgstr ""
 
 msgid "rules.emotional_security_explanation"
 msgstr ""
 
-msgid "rules.ethnicity_label"
-msgstr ""
-
-msgid "rules.ethnicity_explanation"
-msgstr ""
-
-msgid "rules.exaggerating_label"
+msgid "rules.exaggerating_anchor"
 msgstr ""
 
 msgid "rules.exaggerating_explanation"
 msgstr ""
 
-msgid "rules.female_stereotype_label"
+msgid "rules.female_stereotype_anchor"
 msgstr ""
 
 msgid "rules.female_stereotype_explanation"
 msgstr ""
 
-msgid "rules.filler_label"
+msgid "rules.filler_anchor"
 msgstr ""
 
 msgid "rules.filler_explanation"
 msgstr ""
 
-msgid "rules.formality_label"
+msgid "rules.formality_anchor"
 msgstr ""
 
 msgid "rules.formality_explanation"
 msgstr ""
 
-msgid "rules.function_label"
+msgid "rules.function_anchor"
 msgstr ""
 
 msgid "rules.function_explanation"
 msgstr ""
 
-msgid "rules.gen_boomer_label"
+msgid "rules.gen_boomer_anchor"
 msgstr ""
 
 msgid "rules.gen_boomer_explanation"
 msgstr ""
 
-msgid "rules.gen_z_label"
+msgid "rules.gen_z_anchor"
 msgstr ""
 
 msgid "rules.gen_z_explanation"
 msgstr ""
 
-msgid "rules.gender_identity_label"
+msgid "rules.gender_identity_anchor"
 msgstr ""
 
 msgid "rules.gender_identity_explanation"
 msgstr ""
 
-msgid "rules.gendered_label"
+msgid "rules.gendered_anchor"
 msgstr ""
 
 msgid "rules.gendered_explanation"
 msgstr ""
 
-msgid "rules.gendered_denominations_ending_label"
+msgid "rules.gendered_denominations_ending_anchor"
 msgstr ""
 
 msgid "rules.gendered_denominations_ending_explanation"
 msgstr ""
 
-msgid "rules.generic_plural_label"
+msgid "rules.generic_plural_anchor"
 msgstr ""
 
 msgid "rules.generic_plural_explanation"
 msgstr ""
 
-msgid "rules.hearing_label"
+msgid "rules.hearing_anchor"
 msgstr ""
 
 msgid "rules.hearing_explanation"
 msgstr ""
 
-msgid "rules.hidden_image_label"
+msgid "rules.hidden_image_anchor"
 msgstr ""
 
 msgid "rules.hidden_image_explanation"
 msgstr ""
 
-msgid "rules.hollow_label"
+msgid "rules.hollow_anchor"
 msgstr ""
 
 msgid "rules.hollow_explanation"
 msgstr ""
 
-msgid "rules.homophobia_label"
+msgid "rules.homophobia_anchor"
 msgstr ""
 
 msgid "rules.homophobia_explanation"
 msgstr ""
 
-msgid "rules.inclusive_label"
+msgid "rules.inclusive_anchor"
 msgstr ""
 
 msgid "rules.inclusive_explanation"
 msgstr ""
 
-msgid "rules.job_requirements_label"
+msgid "rules.job_requirements_anchor"
 msgstr ""
 
 msgid "rules.job_requirements_explanation"
 msgstr ""
 
-msgid "rules.leadership_label"
+msgid "rules.leadership_anchor"
 msgstr ""
 
 msgid "rules.leadership_explanation"
 msgstr ""
 
-msgid "rules.learning_label"
+msgid "rules.learning_anchor"
 msgstr ""
 
 msgid "rules.learning_explanation"
 msgstr ""
 
-msgid "rules.male_stereotype_label"
+msgid "rules.male_stereotype_anchor"
 msgstr ""
 
 msgid "rules.male_stereotype_explanation"
 msgstr ""
 
-msgid "rules.medical_state_label"
+msgid "rules.medical_state_anchor"
 msgstr ""
 
 msgid "rules.medical_state_explanation"
 msgstr ""
 
-msgid "rules.mental_wellbeing_label"
+msgid "rules.mental_wellbeing_anchor"
 msgstr ""
 
 msgid "rules.mental_wellbeing_explanation"
 msgstr ""
 
-msgid "rules.migration_label"
+msgid "rules.migration_anchor"
 msgstr ""
 
 msgid "rules.migration_explanation"
 msgstr ""
 
-msgid "rules.military_source_label"
+msgid "rules.military_source_anchor"
 msgstr ""
 
 msgid "rules.military_source_explanation"
 msgstr ""
 
-msgid "rules.misgendering_institutions_label"
+msgid "rules.misgendering_institutions_anchor"
 msgstr ""
 
 msgid "rules.misgendering_institutions_explanation"
 msgstr ""
 
-msgid "rules.mobility_label"
+msgid "rules.mobility_anchor"
 msgstr ""
 
 msgid "rules.mobility_explanation"
 msgstr ""
 
-msgid "rules.offensive_language_label"
+msgid "rules.offensive_language_anchor"
 msgstr ""
 
 msgid "rules.offensive_language_explanation"
 msgstr ""
 
-msgid "rules.openly_discriminating_label"
+msgid "rules.openly_discriminating_anchor"
 msgstr ""
 
 msgid "rules.openly_discriminating_explanation"
 msgstr ""
 
-msgid "rules.orthography_label"
+msgid "rules.orthography_anchor"
 msgstr ""
 
 msgid "rules.orthography_explanation"
 msgstr ""
 
-msgid "rules.overload_label"
-msgstr ""
-
-msgid "rules.overload_explanation"
-msgstr ""
-
-msgid "rules.passive_voice_label"
+msgid "rules.passive_voice_anchor"
 msgstr ""
 
 msgid "rules.passive_voice_explanation"
 msgstr ""
 
-msgid "rules.pressure_label"
+msgid "rules.pressure_anchor"
 msgstr ""
 
 msgid "rules.pressure_explanation"
 msgstr ""
 
-msgid "rules.racism_label"
+msgid "rules.racism_anchor"
 msgstr ""
 
 msgid "rules.racism_explanation"
 msgstr ""
 
-msgid "rules.racist_source_label"
+msgid "rules.racist_source_anchor"
 msgstr ""
 
 msgid "rules.racist_source_explanation"
 msgstr ""
 
-msgid "rules.salary_vague_label"
-msgstr ""
-
-msgid "rules.salary_vague_explanation"
-msgstr ""
-
-msgid "rules.sexism_label"
+msgid "rules.sexism_anchor"
 msgstr ""
 
 msgid "rules.sexism_explanation"
 msgstr ""
 
-msgid "rules.sexual_orientation_label"
+msgid "rules.sexual_orientation_anchor"
 msgstr ""
 
 msgid "rules.sexual_orientation_explanation"
 msgstr ""
 
-msgid "rules.speech_label"
+msgid "rules.speech_anchor"
 msgstr ""
 
 msgid "rules.speech_explanation"
 msgstr ""
 
-msgid "rules.sports_terms_label"
+msgid "rules.sports_terms_anchor"
 msgstr ""
 
 msgid "rules.sports_terms_explanation"
 msgstr ""
 
-msgid "rules.style_label"
+msgid "rules.style_anchor"
 msgstr ""
 
 msgid "rules.style_explanation"
 msgstr ""
 
-msgid "rules.technical_frameworks_label"
-msgstr ""
-
-msgid "rules.technical_frameworks_explanation"
-msgstr ""
-
-msgid "rules.titles_label"
+msgid "rules.titles_anchor"
 msgstr ""
 
 msgid "rules.titles_explanation"
 msgstr ""
 
-msgid "rules.transphobia_label"
+msgid "rules.transphobia_anchor"
 msgstr ""
 
 msgid "rules.transphobia_explanation"
 msgstr ""
 
-msgid "rules.unconscious_bias_label"
+msgid "rules.unconscious_bias_anchor"
 msgstr ""
 
 msgid "rules.unconscious_bias_explanation"
 msgstr ""
 
-msgid "rules.verbose_label"
-msgstr ""
-
-msgid "rules.verbose_explanation"
-msgstr ""
-
-msgid "rules.vision_label"
+msgid "rules.vision_anchor"
 msgstr ""
 
 msgid "rules.vision_explanation"
 msgstr ""
 
-msgid "rules.workload_label"
-msgstr ""
-
-msgid "rules.workload_explanation"
-msgstr ""
-
-msgid "rules.xenophobia_label"
+msgid "rules.xenophobia_anchor"
 msgstr ""
 
 msgid "rules.xenophobia_explanation"

--- a/tests/test_demo_wordings_english/test_internal_email/output.json
+++ b/tests/test_demo_wordings_english/test_internal_email/output.json
@@ -189,7 +189,7 @@
                 "url": "https://www.witty.works/en/categories/style#empty_words"
             },
             "gravity": 3.0,
-            "label": "Style: Empty Words",
+            "label": "Style: Empty words",
             "start": 143,
             "subcategory": "hollow",
             "text": "innovation"

--- a/tests/test_demo_wordings_german/test_internal_email/output.json
+++ b/tests/test_demo_wordings_german/test_internal_email/output.json
@@ -16,7 +16,7 @@
                 "text": "Außer am Satzanfang werden nur Nomen und Eigennamen großgeschrieben."
             },
             "gravity": 1.0,
-            "label": "Groß-/Kleinschreibung",
+            "label": "Gross-/Kleinschreibung",
             "start": 22,
             "subcategory": "casing",
             "text": "Wir"

--- a/tests/test_general_cases/test_api_english_singular_they/output.json
+++ b/tests/test_general_cases/test_api_english_singular_they/output.json
@@ -17,7 +17,7 @@
                 "url": "https://www.witty.works/en/categories/gendered#binary_pronouns"
             },
             "gravity": 2.0,
-            "label": "Gendered: Binary Pronouns",
+            "label": "Gendered: Binary pronouns",
             "start": 12,
             "subcategory": "binary_pronouns",
             "text": "he"

--- a/tests/test_general_cases/test_api_orthography_swiss_german/output.json
+++ b/tests/test_general_cases/test_api_orthography_swiss_german/output.json
@@ -16,7 +16,7 @@
                 "text": "Ausser am Satzanfang werden nur Nomen und Eigennamen grossgeschrieben."
             },
             "gravity": 1.0,
-            "label": "Groß-/Kleinschreibung",
+            "label": "Gross-/Kleinschreibung",
             "start": 39,
             "subcategory": "casing",
             "text": "Wie"

--- a/tests/test_general_cases/test_api_text_max_length/output.json
+++ b/tests/test_general_cases/test_api_text_max_length/output.json
@@ -16,7 +16,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 102,
             "subcategory": "typos",
             "text": "metres"
@@ -79,7 +79,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 191,
             "subcategory": "typos",
             "text": "metres"
@@ -120,7 +120,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 382,
             "subcategory": "typos",
             "text": "metres"
@@ -139,7 +139,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 418,
             "subcategory": "typos",
             "text": "metres"
@@ -158,7 +158,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 551,
             "subcategory": "typos",
             "text": "metres"
@@ -199,7 +199,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 723,
             "subcategory": "typos",
             "text": "metres"
@@ -262,7 +262,7 @@
                 "text": "Possible spelling mistake. ‘metres’ is British English."
             },
             "gravity": 1.0,
-            "label": "Possible Typo",
+            "label": "Possible typo",
             "start": 812,
             "subcategory": "typos",
             "text": "metres"
@@ -428,7 +428,7 @@
                 "url": "https://www.witty.works/en/categories/style#filler_words"
             },
             "gravity": 3.0,
-            "label": "Style: Filler Words",
+            "label": "Style: Filler words",
             "start": 321,
             "subcategory": "filler",
             "text": "generally"
@@ -448,7 +448,7 @@
                 "url": "https://www.witty.works/en/categories/style#filler_words"
             },
             "gravity": 3.0,
-            "label": "Style: Filler Words",
+            "label": "Style: Filler words",
             "start": 942,
             "subcategory": "filler",
             "text": "generally"

--- a/tests/test_language_detection/test_language_detection_german/output.json
+++ b/tests/test_language_detection/test_language_detection_german/output.json
@@ -16,7 +16,7 @@
                 "text": "Dieser Satz fängt nicht mit einem großgeschriebenen Wort an."
             },
             "gravity": 1.0,
-            "label": "Groß-/Kleinschreibung",
+            "label": "Gross-/Kleinschreibung",
             "start": 0,
             "subcategory": "casing",
             "text": "liebe"

--- a/tests/test_lemmatizers/test_english_lemmatizer/output.json
+++ b/tests/test_lemmatizers/test_english_lemmatizer/output.json
@@ -94,7 +94,7 @@
                 "url": "https://www.witty.works/en/categories/style#empty_words"
             },
             "gravity": 3.0,
-            "label": "Style: Empty Words",
+            "label": "Style: Empty words",
             "start": 55,
             "subcategory": "hollow",
             "text": "state-of-the-art"

--- a/tests/test_sentry_examples/test_english_morph_token/output.json
+++ b/tests/test_sentry_examples/test_english_morph_token/output.json
@@ -147,7 +147,7 @@
                 "url": "https://www.witty.works/en/categories/style#empty_words"
             },
             "gravity": 3.0,
-            "label": "Style: Empty Words",
+            "label": "Style: Empty words",
             "start": 20,
             "subcategory": "hollow",
             "text": "first"

--- a/tests/test_term_replacement/test_api_corporate_term_replacements/output.json
+++ b/tests/test_term_replacement/test_api_corporate_term_replacements/output.json
@@ -115,7 +115,7 @@
                 "url": "https://witty.works"
             },
             "gravity": 0.9,
-            "label": "Organisations-Leitlinie",
+            "label": "Organisations Leitlinie",
             "start": 8,
             "subcategory": "corporate_rules",
             "text": "foo"


### PR DESCRIPTION
we now dropped the "category label" column and instead of an explicit "anchor" column in https://www.notion.so/e68e073dd0a342fca2a6683c7a8b2341?v=b54da99f8a6b4e6e8f312a530f653eb0 