### PR TITLE
make it possible to enable 'leichte Sprache' in de-DE

### DIFF
--- a/app/categories.py
+++ b/app/categories.py
@@ -449,8 +449,8 @@ categories = {
     "simple_language": {
         "inclusive": False,
         "category": "style",
-        "gravity": 2.0,
-        "importance": None,
+        "gravity": 3.0,
+        "importance": 2,
         "emoji": "🙄",
     },
     "speech": {

--- a/app/main.py
+++ b/app/main.py
@@ -1009,11 +1009,26 @@ def languagetool_matches(
             if subcategory in lt_style_categories:
                 category = "style"
 
-            subcategory = subcategory.lower()
-            if subcategory == "style":
-                subcategory = "general_style"
-            elif subcategory not in categories:
-                subcategory = category
+            if subcategory == "DIFFICULT_WORDS":
+                category = "style"
+                if match["rule"]["id"] == "ABKUERZUNG":
+                    subcategory = "abbreviation"
+                elif (
+                    match["rule"]["id"] == "ANGLIZISMEN"
+                    or "Fremdwörter" in match["message"]
+                ):
+                    subcategory = "anglicism"
+                else:
+                    subcategory = "simple_language"
+            elif match["rule"]["category"]["name"] == "Leichte Sprache":
+                category = "style"
+                subcategory = "simple_language"
+            else:
+                subcategory = subcategory.lower()
+                if subcategory == "style":
+                    subcategory = "general_style"
+                elif subcategory not in categories:
+                    subcategory = category
         except KeyError:
             subcategory = category
 
@@ -1029,16 +1044,24 @@ def languagetool_matches(
             except KeyError:
                 pass
 
-        anchor = (
-            label.lower()
-            .replace(" ", "_")
-            .replace("ß", "ss")
-            .replace("ü", "ue")
-            .replace("ä", "ae")
-            .replace("ö", "oe")
-        )
+        if category != "style":
+            anchor = (
+                label.lower()
+                .replace(" ", "_")
+                .replace("ß", "ss")
+                .replace("ü", "ue")
+                .replace("ä", "ae")
+                .replace("ö", "oe")
+            )
+        else:
+            anchor = None
 
-        explanation = match["message"]
+        if category != "style" or (
+            subcategory != "abbreviation" and subcategory != "anglicism"
+        ):
+            explanation = match["message"]
+        else:
+            explanation = None
 
         list_results.append(
             ResultOut.factory(
@@ -1066,10 +1089,14 @@ async def languagetool_rules(version: float, config: Config, lang: Language, tex
     async with ClientSession(
         connector=TCPConnector(verify_ssl=settings.languagetool_verify_ssl)
     ) as session:
+
         payload = {
             "text": text,
             "language": lang.locale,
         }
+
+        if config.simple_language and payload["language"] == "de-DE":
+            payload["language"] += "-x-simple-language"
 
         if config.primary_language != None:
             payload["motherTongue"] = config.primary_language

--- a/app/models.py
+++ b/app/models.py
@@ -94,6 +94,7 @@ class GenderedRolesFormatType(str, Enum):
 
 class Config(BaseModel):
     store_context: Optional[bool] = True
+    simple_language: Optional[bool] = False
     primary_language: Optional[LangWithAutoType]
     preferred_languages: List = [LangWithAutoType.EN, LangWithAutoType.DE]
     _supported_langs = [
@@ -234,6 +235,7 @@ class SingularTheyConfigType(BaseModel):
 
 class RuleConfig(BaseModel):
     store_context: Optional[BooleanConfigType]
+    simple_language: Optional[BooleanConfigType]
     preferred_variants: Optional[LangVariantConfigType]
     german_gender_ending: Optional[GermanGenderEndingConfigType]
     gendered_roles_format: Optional[GenderedRolesFormatConfigType]

--- a/tests/test_general_cases/test_german_simple_language/input.json
+++ b/tests/test_general_cases/test_german_simple_language/input.json
@@ -1,0 +1,7 @@
+{
+    "text": "Fügen Sie hier Ihren Text ein oder benutzen Sie diesen Text als Beispiel. Dieser Text wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie erst einmal wieder herausfinden müssen.",
+    "config": {
+        "maximum_importance": 3,
+        "simple_language": true
+    }
+}

--- a/tests/test_general_cases/test_german_simple_language/output.json
+++ b/tests/test_general_cases/test_german_simple_language/output.json
@@ -1,0 +1,532 @@
+{
+    "language": "de",
+    "limit_reached": false,
+    "results": [
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "Fügen Sie hier Ihren Text ein oder benutzen Sie diesen Text als Beispiel. Dieser Text wurde nur zum Testen geschrieben. Die Donaudampf",
+            "end": 34,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Jeder Satz sollte nur eine Aussage enthalten. Können Sie diesen Satz in mehrere Sätze aufteilen?",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 30,
+            "subcategory": "simple_language",
+            "text": "oder"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "ie hier Ihren Text ein oder benutzen Sie diesen Text als Beispiel. Dieser Text wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre s",
+            "end": 118,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Passiv gefunden. Benutzen Sie aktive Wörter.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 107,
+            "subcategory": "simple_language",
+            "text": "geschrieben"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "t ein oder benutzen Sie diesen Text als Beispiel. Dieser Text wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glüc",
+            "end": 145,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Dieses Wort hat mehr als dreizehn Buchstaben. Benutzen Sie kurze Wörter.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 124,
+            "subcategory": "simple_language",
+            "text": "Donaudampfschifffahrt"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "Text als Beispiel. Dieser Text wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden",
+            "end": 159,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Wenn möglich, keine Verneinungen benutzen.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 154,
+            "subcategory": "simple_language",
+            "text": "nicht"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "eser Text wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI g",
+            "end": 183,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie abstrakte Wörter. Benutzen Sie möglichst konkrete Aussagen.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 176,
+            "subcategory": "simple_language",
+            "text": "Nutzung"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "t wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das b",
+            "end": 196,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie den Genitiv.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 184,
+            "subcategory": "simple_language",
+            "text": "des Genitivs"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "rieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing",
+            "end": 216,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie den Konjunktiv.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 212,
+            "subcategory": "simple_language",
+            "text": "wäre"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "pfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Per",
+            "end": 236,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie Nebensätze.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 232,
+            "subcategory": "simple_language",
+            "text": "dass"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "ahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell",
+            "end": 252,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie Metaphern und bildhafte Sprache.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 241,
+            "subcategory": "simple_language",
+            "text": "Glückspilze"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "tzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*inne",
+            "end": 281,
+            "explanation": {
+                "icon": "😉",
+                "text": "Werden alle Lesenden diese Abkürzung verstehen?",
+                "url": "https://www.witty.works/de/kategorien/stil#abkuerzung"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Abkürzung",
+            "start": 278,
+            "subcategory": "abbreviation",
+            "text": "KPI"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": ". Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer L",
+            "end": 315,
+            "explanation": {
+                "icon": "😉",
+                "text": "Anglizismen: Sicher, dass das alle Lesenden verstehen?",
+                "url": "https://www.witty.works/de/kategorien/stil#anglizismen"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Anglizismen",
+            "start": 307,
+            "subcategory": "anglicism",
+            "text": "Briefing"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "ass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen",
+            "end": 344,
+            "explanation": {
+                "icon": "😉",
+                "text": "Anglizismen: Sicher, dass das alle Lesenden verstehen?",
+                "url": "https://www.witty.works/de/kategorien/stil#anglizismen"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Anglizismen",
+            "start": 333,
+            "subcategory": "anglicism",
+            "text": "Performance"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie",
+            "end": 364,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie Nebensätze.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 361,
+            "subcategory": "simple_language",
+            "text": "wie"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "e KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort,",
+            "end": 377,
+            "explanation": {
+                "icon": "🤔",
+                "text": "Vermeiden Sie Sonderzeichen.",
+                "url": "https://www.witty.works/de/kategorien/stil#verschiedenes"
+            },
+            "gravity": 2.0,
+            "label": "Stil: Verschiedenes",
+            "start": 376,
+            "subcategory": "general_style",
+            "text": "*"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "g und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze,",
+            "end": 420,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie abstrakte Wörter. Benutzen Sie möglichst konkrete Aussagen.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 414,
+            "subcategory": "simple_language",
+            "text": "Lösung"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "ere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie e",
+            "end": 436,
+            "explanation": {
+                "icon": "😉",
+                "text": "Anglizismen: Sicher, dass das alle Lesenden verstehen?",
+                "url": "https://www.witty.works/de/kategorien/stil#anglizismen"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Anglizismen",
+            "start": 429,
+            "subcategory": "anglicism",
+            "text": "Problem"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": ". Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie erst einmal",
+            "end": 447,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Jeder Satz sollte nur eine Aussage enthalten. Können Sie diesen Satz in mehrere Sätze aufteilen?",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 444,
+            "subcategory": "simple_language",
+            "text": "und"
+        },
+        {
+            "alternatives": [],
+            "category": "style",
+            "context": "*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie erst einmal wieder herausfinden müssen.",
+            "end": 573,
+            "explanation": {
+                "icon": "🙄",
+                "text": "Vermeiden Sie den Konjunktiv. Vermeiden Sie auch indirekte Rede.",
+                "url": "https://www.witty.works/de/kategorien/stil#leichte_sprache"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Leichte Sprache",
+            "start": 476,
+            "subcategory": "simple_language",
+            "text": ", verpackt in labyrinthische Schachtelsätze, aus denen sie erst einmal wieder herausfinden müssen"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "Key Performance Indicator (KPI)"
+                },
+                {
+                    "text": "Leistungskennzahl"
+                },
+                {
+                    "text": "Kennzahl"
+                }
+            ],
+            "category": "style",
+            "context": "tzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*inne",
+            "end": 281,
+            "explanation": {
+                "icon": "😉",
+                "text": "Werden alle Lesenden diese Abkürzung verstehen?",
+                "url": "https://www.witty.works/de/kategorien/stil#abkuerzung"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Abkürzung",
+            "start": 278,
+            "subcategory": "abbreviation",
+            "text": "KPI"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "Kernfrage"
+                },
+                {
+                    "text": "komplexe Aufgabe"
+                },
+                {
+                    "text": "schwere Frage"
+                },
+                {
+                    "text": "schwieriges Thema"
+                },
+                {
+                    "text": "komplexe Materie"
+                },
+                {
+                    "text": "Fragestellung"
+                },
+                {
+                    "text": "Schwachpunkt"
+                },
+                {
+                    "text": "Beeinträchtigung"
+                },
+                {
+                    "text": "Erschwernis"
+                },
+                {
+                    "text": "Haken"
+                },
+                {
+                    "text": "Schwierigkeit"
+                },
+                {
+                    "text": "Hindernis"
+                },
+                {
+                    "text": "Engpass"
+                },
+                {
+                    "text": "Komplikation"
+                },
+                {
+                    "text": "Fehler"
+                },
+                {
+                    "text": "Bürde"
+                },
+                {
+                    "text": "Hürde"
+                },
+                {
+                    "text": "Fallstrick"
+                },
+                {
+                    "text": "missliche Lage"
+                },
+                {
+                    "text": "Unsicherheit"
+                }
+            ],
+            "category": "unconscious_bias",
+            "context": "ere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie e",
+            "end": 436,
+            "explanation": {
+                "icon": "😒",
+                "text": "Spricht kooperativ denkende Menschen nicht an",
+                "url": "https://www.witty.works/de/kategorien/sprachliche_voreingenommenheit#agentisch"
+            },
+            "gravity": 2.0,
+            "label": "Sprachliche Voreingenommenheit: Agentisch",
+            "start": 429,
+            "subcategory": "agentic",
+            "text": "Problem"
+        },
+        {
+            "alternatives": [],
+            "category": "inclusive",
+            "context": "unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer Lösung für ihr Problem suchen und dann finden sie eine Antwort, v",
+            "end": 379,
+            "explanation": {
+                "icon": "✅",
+                "text": "Bestärkt Wert von Diversity, Gleichstellung und Inklusion",
+                "url": "https://www.witty.works/de/kategorien/inklusiv#diversitaet_&_inklusion"
+            },
+            "label": "Inklusiv: Diversität & Inklusion",
+            "start": 371,
+            "subcategory": "d_and_i",
+            "text": "Leser*in"
+        },
+        {
+            "alternatives": [
+                {
+                    "remove": true
+                }
+            ],
+            "category": "style",
+            "context": "Fügen Sie hier Ihren Text ein oder benutzen Sie diesen Text als Beispiel. Dieser Text wurde nur zum Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitiv",
+            "end": 95,
+            "explanation": {
+                "icon": "😟",
+                "text": "Füllwörter machen Text länger und unverständlicher",
+                "url": "https://www.witty.works/de/kategorien/stil#fuellwoerter"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Füllwörter",
+            "start": 92,
+            "subcategory": "filler",
+            "text": "nur"
+        },
+        {
+            "alternatives": [
+                {
+                    "remove": true
+                }
+            ],
+            "category": "style",
+            "context": "um Testen geschrieben. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das brauch",
+            "end": 201,
+            "explanation": {
+                "icon": "😟",
+                "text": "Füllwörter machen Text länger und unverständlicher",
+                "url": "https://www.witty.works/de/kategorien/stil#fuellwoerter"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Füllwörter",
+            "start": 197,
+            "subcategory": "filler",
+            "text": "auch"
+        },
+        {
+            "alternatives": [
+                {
+                    "remove": true
+                }
+            ],
+            "category": "style",
+            "context": "n. Die Donaudampfschifffahrt darf da nicht fehlen. Und die Nutzung des Genitivs auch nicht. Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und ei",
+            "end": 222,
+            "explanation": {
+                "icon": "😟",
+                "text": "Füllwörter machen Text länger und unverständlicher",
+                "url": "https://www.witty.works/de/kategorien/stil#fuellwoerter"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Füllwörter",
+            "start": 217,
+            "subcategory": "filler",
+            "text": "sogar"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "Pressekonferenz"
+                }
+            ],
+            "category": "style",
+            "context": ". Es wäre sogar möglich, dass Sie Glückspilze finden. Haben sie unsere KPI gesehen? Das braucht ein Briefing und eine bessere Performance. Stell dir vor, wie deine Leser*innen in der Suchmaschine nach einer L",
+            "end": 315,
+            "explanation": {
+                "icon": "😉",
+                "text": "Anglizismen: Sicher, dass das alle Lesenden verstehen?",
+                "url": "https://www.witty.works/de/kategorien/stil#anglizismen"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Anglizismen",
+            "start": 307,
+            "subcategory": "anglicism",
+            "text": "Briefing"
+        },
+        {
+            "alternatives": [
+                {
+                    "remove": true
+                }
+            ],
+            "category": "style",
+            "context": "hen und dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie erst einmal wieder herausfinden müssen.",
+            "end": 546,
+            "explanation": {
+                "icon": "😟",
+                "text": "Füllwörter machen Text länger und unverständlicher",
+                "url": "https://www.witty.works/de/kategorien/stil#fuellwoerter"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Füllwörter",
+            "start": 540,
+            "subcategory": "filler",
+            "text": "einmal"
+        },
+        {
+            "alternatives": [
+                {
+                    "remove": true
+                }
+            ],
+            "category": "style",
+            "context": "dann finden sie eine Antwort, verpackt in labyrinthische Schachtelsätze, aus denen sie erst einmal wieder herausfinden müssen.",
+            "end": 553,
+            "explanation": {
+                "icon": "😟",
+                "text": "Füllwörter machen Text länger und unverständlicher",
+                "url": "https://www.witty.works/de/kategorien/stil#fuellwoerter"
+            },
+            "gravity": 3.0,
+            "label": "Stil: Füllwörter",
+            "start": 547,
+            "subcategory": "filler",
+            "text": "wieder"
+        }
+    ]
+}


### PR DESCRIPTION
fixes https://github.com/witty-works/nlp_api/issues/610

this is more "einfache sprache" than actually "leichte sprache" but we may need to tweak this more to figure out what we want to include in a "einfache sprache" subcategory and what to include in a "leichte sprache" subcategory.

example test case taken from https://languagetool.org/de/leichte-sprache

overview of the rules supported:
https://multisprech.org/einfache-sprache/einfach-schreiben/languagetool-leichte-sprache/

also given that these rules highlight the beginning of subsentences, it indirectly already covers long sentences which is an interesting approach.

note this all only works in de-DE, there is no equivalent for Swiss/Austrian German, let alone English.