### PR TITLE
handle multi byte characters according to UTF-16

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -433,6 +433,7 @@ def get_root():
 
     return "Witty NLP API: https://witty.works"
 
+
 @app.get(
     "/save_openapi_json",
     include_in_schema=not settings.is_prod,
@@ -1325,7 +1326,7 @@ def has_gender_denom_ending(text, full_text, offset, config: Config):
 
 
 def languagetool_matches(
-    version: float, config: Config, lang: Language, text: str, result
+    version: float, config: Config, lang: Language, full_text: str, offsets, result
 ):
     list_results = []
     ignore = ["@", "#"]
@@ -1337,12 +1338,19 @@ def languagetool_matches(
     for match in result["matches"]:
         start = int(match["offset"])
         end = start + int(match["length"])
-        highlight_text = text[start:end]
+
+        if offsets and len(offsets["utf16_chars"]) > start:
+            start = offsets["utf16_chars"][start]
+
+        if offsets and len(offsets["utf16_chars"]) > end:
+            end = offsets["utf16_chars"][end]
+
+        text = full_text[start:end]
 
         # Ignore capitalization after German salutation
         if match["rule"]["category"]["id"] == "TYPOS":
             subtext = (
-                text[0:start]
+                full_text[0:start]
                 .lstrip()
                 .lower()
                 .replace("'", "")
@@ -1359,20 +1367,18 @@ def languagetool_matches(
             lang.lang == "de"
             and config.german_gender_ending == ":in"
             and match["rule"]["id"] == "LEERZEICHEN_HINTER_DOPPELPUNKT"
-            and text[start + 1 : end] in rules["de"]["male_articles"]
+            and full_text[start + 1 : end] in rules["de"]["male_articles"]
         ):
             continue
 
-        # ignore text that starts with @ or #
-        if highlight_text[0:1] in ignore or (
-            start > 0 and text[start - 1 : start] in ignore
+        # ignore full_text that starts with @ or #
+        if text[0:1] in ignore or (
+            start > 0 and full_text[start - 1 : start] in ignore
         ):
             continue
 
         # ignore german gender ending as spelling mistakes
-        if gendered_denom and has_gender_denom_ending(
-            highlight_text, text, start, config
-        ):
+        if gendered_denom and has_gender_denom_ending(text, full_text, start, config):
             continue
 
         try:
@@ -1427,8 +1433,9 @@ def languagetool_matches(
                 version,
                 config,
                 lang,
-                highlight_text,
                 text,
+                full_text,
+                offsets,
                 subcategory,
                 start,
                 end,
@@ -1501,7 +1508,7 @@ async def fetch_json_post(url, payload, headers, name, ssl=True, json=True):
 
 
 async def apply_languagetool_rules(
-    version: float, config: Config, lang: Language, text: str
+    version: float, config: Config, lang: Language, text: str, offsets
 ):
     if settings.languagetool_api == "":
         return []
@@ -1546,12 +1553,41 @@ async def apply_languagetool_rules(
     if not isinstance(result, dict):
         return []
 
-    return languagetool_matches(version, config, lang, text, result)
+    return languagetool_matches(version, config, lang, text, offsets, result)
+
+
+def utf16len(c):
+    """Returns the length of the single character 'c'
+    in UTF-16 code units."""
+    return 1 if ord(c) < 65536 else 2
 
 
 def fetch_tokens(lang, text: str):
-    # apply SpaCy pre-built model
     return model[lang](text.rstrip().replace("\n", " "))
+
+
+def utf16_offsets(text):
+    utf16offset = 0
+
+    offsets = {
+        "chars": [],
+        "utf16_chars": [],
+    }
+
+    counter = 0
+    for char in [*text]:
+        offsets["chars"].append(counter + utf16offset)
+        offsets["utf16_chars"].append(counter - utf16offset)
+
+        counter += 1
+
+        if utf16len(char) > 1:
+            utf16offset += 1
+
+    offsets["chars"].append(counter + utf16offset)
+    offsets["utf16_chars"].append(counter - utf16offset)
+
+    return offsets if utf16offset else False
 
 
 # matcher to false positives
@@ -1649,7 +1685,13 @@ async def apply_language_rules(
 
 
 def apply_term_replacements(
-    tokens, version: float, config: Config, configs: dict, lang: Language, text: str
+    version: float,
+    config: Config,
+    lang: Language,
+    text: str,
+    tokens,
+    offsets,
+    configs: dict,
 ):
     if "term_replacements" not in configs:
         return []
@@ -1711,6 +1753,7 @@ def apply_term_replacements(
             config,
             lang,
             text,
+            offsets,
             term_replacements_case_insensitive,
             "corporate_rules",
         )
@@ -1721,6 +1764,7 @@ def apply_term_replacements(
             config,
             lang,
             text,
+            offsets,
             term_replacements_case_sensitive,
             "corporate_rules",
         )
@@ -1742,6 +1786,7 @@ def apply_term_replacements(
             lang,
             text,
             tokens,
+            offsets,
             term_replacements,
         )
 
@@ -1846,7 +1891,9 @@ async def context_false_positives(lang, tokens, list_results):
 async def german_rules(
     version: float, config: Config, configs: dict, lang: Language, text: str
 ):
-    list_full = await apply_languagetool_rules(version, config, lang, text)
+    offsets = utf16_offsets(text)
+
+    list_full = await apply_languagetool_rules(version, config, lang, text, offsets)
 
     tokens = fetch_tokens(lang.lang, text)
 
@@ -1857,6 +1904,7 @@ async def german_rules(
             lang,
             text,
             tokens,
+            offsets,
             rules["de"]["df_abbreviation"],
             rules["de"]["abbreviation"],
             True,
@@ -1868,6 +1916,7 @@ async def german_rules(
         lang,
         text,
         tokens,
+        offsets,
         rules["de"]["open_disc_words_data"],
         rules["de"]["open_disc_sentences_data"],
         rules["de"]["df_open_dis_sentence"],
@@ -1879,6 +1928,7 @@ async def german_rules(
         lang,
         text,
         tokens,
+        offsets,
         rules["de"]["gender_words_data_no_noun"],
         rules["de"]["gender_sentences_data"],
         rules["de"]["df_gendered_sentences"],
@@ -1888,6 +1938,7 @@ async def german_rules(
         lang,
         text,
         tokens,
+        offsets,
         rules["de"]["gender_words_data"],
         rules["de"]["false_positives"].gender,
     )
@@ -1898,6 +1949,7 @@ async def german_rules(
             config,
             lang,
             text,
+            offsets,
             rules["m_f_regexes"],
             "gender_specific_abbreviation",
         )
@@ -1921,6 +1973,7 @@ async def german_rules(
             config,
             lang,
             text,
+            offsets,
             regexes,
             subcategory,
         )
@@ -1931,6 +1984,7 @@ async def german_rules(
         lang,
         text,
         tokens,
+        offsets,
         rules["de"]["bias_words_data_no_plur"],
         rules["de"]["bias_sentences_data"],
         rules["de"]["df_ub_sentences"],
@@ -1940,6 +1994,7 @@ async def german_rules(
         lang,
         text,
         tokens,
+        offsets,
         rules["de"]["bias_words_data_noun"],
     )
 
@@ -1950,6 +2005,7 @@ async def german_rules(
             lang,
             text,
             tokens,
+            offsets,
             rules["de"]["df_communal_words"],
             None,
             [],
@@ -1964,6 +2020,7 @@ async def german_rules(
             lang,
             text,
             tokens,
+            offsets,
             rules["de"]["df_d_and_i_words"],
             None,
             rules["de"]["df_terms_d_and_i_words"],
@@ -1976,7 +2033,9 @@ async def german_rules(
 
         regexes.update(rules["d_f_m_regexes"])
 
-        list_full += regex_matches(version, config, lang, text, regexes, subcategory)
+        list_full += regex_matches(
+            version, config, lang, text, offsets, regexes, subcategory
+        )
 
     list_full += style_word_analysis_de(
         version,
@@ -1984,6 +2043,7 @@ async def german_rules(
         lang,
         text,
         tokens,
+        offsets,
         rules["de"]["terms_style"],
         rules["de"]["style_words_data"],
         rules["de"]["style_sentences_data"],
@@ -1995,9 +2055,12 @@ async def german_rules(
         config,
         lang,
         text,
+        offsets,
     )
 
-    list_full += apply_term_replacements(tokens, version, config, configs, lang, text)
+    list_full += apply_term_replacements(
+        version, config, lang, text, tokens, offsets, configs
+    )
 
     return await context_false_positives(lang.lang, tokens, list_full)
 
@@ -2005,7 +2068,9 @@ async def german_rules(
 async def english_rules(
     version: float, config: Config, configs: dict, lang: Language, text: str
 ):
-    list_full = await apply_languagetool_rules(version, config, lang, text)
+    offsets = utf16_offsets(text)
+
+    list_full = await apply_languagetool_rules(version, config, lang, text, offsets)
 
     tokens = fetch_tokens(lang.lang, text)
 
@@ -2040,6 +2105,7 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         matches_false,
         words_data_en["homonym"],
     )
@@ -2051,6 +2117,7 @@ async def english_rules(
             lang,
             text,
             tokens,
+            offsets,
             rules[lang.locale]["df_abbreviation"],
             words_data_en["abbr"],
             True,
@@ -2062,6 +2129,7 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         words_data_en["od"],
         sentences_data_en["od"],
         rules[lang.locale]["df_open_dis_sentence"],
@@ -2074,6 +2142,7 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         words_data_en["ge"],
         sentences_data_en["ge"],
         rules[lang.locale]["df_gendered_sentence"],
@@ -2087,6 +2156,7 @@ async def english_rules(
             lang,
             text,
             tokens,
+            offsets,
             words_data_en["ge-singular-they"],
             sentences_data_en["ge"],
             rules[lang.locale]["df_gendered_sentence"],
@@ -2101,6 +2171,7 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         gendered_words_data_en["gendered"],
         matches_false,
     )
@@ -2111,6 +2182,7 @@ async def english_rules(
             config,
             lang,
             text,
+            offsets,
             rules["m_f_regexes"],
             "gender_specific_abbreviation",
         )
@@ -2123,6 +2195,7 @@ async def english_rules(
             config,
             lang,
             text,
+            offsets,
             rules["d_f_m_regexes"],
             subcategory,
         )
@@ -2133,6 +2206,7 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         inclusive_words_data_en,
         inclusive_sentences_data_en,
         rules[lang.locale]["df_inclusive_sentence"],
@@ -2146,6 +2220,7 @@ async def english_rules(
             lang,
             text,
             tokens,
+            offsets,
             words_data_en["style"],
             sentences_data_en["style"],
             rules[lang.locale]["df_style_sentence"],
@@ -2157,6 +2232,7 @@ async def english_rules(
             lang,
             text,
             tokens,
+            offsets,
             gendered_words_data_en["style"],
             matches_false,
         )
@@ -2165,6 +2241,7 @@ async def english_rules(
             config,
             lang,
             text,
+            offsets,
         )
     )
 
@@ -2174,6 +2251,7 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         words_data_en["bias"],
         sentences_data_en["bias"],
         rules[lang.locale]["df_ub_sentence"],
@@ -2184,11 +2262,14 @@ async def english_rules(
         lang,
         text,
         tokens,
+        offsets,
         gendered_words_data_en["bias"],
         matches_false,
     )
 
-    list_full += apply_term_replacements(tokens, version, config, configs, lang, text)
+    list_full += apply_term_replacements(
+        version, config, lang, text, tokens, offsets, configs
+    )
 
     return await context_false_positives(lang.lang, tokens, list_full)
 
@@ -2392,7 +2473,9 @@ def german_noun_lookup(word):
     if "flexion" in result:
         for flexion in list(result["flexion"].keys()):
             if "1" in flexion:
-                result["flexion"][flexion.replace(" 1", "")] = result["flexion"][flexion]
+                result["flexion"][flexion.replace(" 1", "")] = result["flexion"][
+                    flexion
+                ]
 
     if "genus" in result:
         return result
@@ -2997,6 +3080,7 @@ def sentences_matches(
     lang,
     full_text,
     tokens,
+    offsets,
     subcategory,
     matches,
 ):
@@ -3013,6 +3097,7 @@ def sentences_matches(
                     lang,
                     span.text,
                     full_text,
+                    offsets,
                     subcategory,
                     span.start_char,
                     span.end_char,
@@ -3028,6 +3113,7 @@ def sentences_matcher(
     lang,
     full_text,
     tokens,
+    offsets,
     sentences_data,
     df_sentence,
     subcategory=None,
@@ -3049,6 +3135,7 @@ def sentences_matcher(
             lang,
             full_text,
             tokens,
+            offsets,
             subcategory,
             matches,
         )
@@ -3072,6 +3159,7 @@ def sentences_matcher(
                         lang,
                         span.text,
                         full_text,
+                        offsets,
                         subcategory,
                         span.start_char,
                         span.end_char,
@@ -3087,6 +3175,7 @@ def regex_matches(
     config: Config,
     lang,
     full_text,
+    offsets,
     regexes,
     subcategory=None,
 ):
@@ -3231,6 +3320,7 @@ def regex_matches(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3251,6 +3341,7 @@ def ub_words_phrase_matcher_de(
     lang,
     full_text,
     tokens,
+    offsets,
     words_data,
     sentences_data,
     df_sentence,
@@ -3279,6 +3370,7 @@ def ub_words_phrase_matcher_de(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3292,6 +3384,7 @@ def ub_words_phrase_matcher_de(
         lang,
         full_text,
         tokens,
+        offsets,
         sentences_data,
         df_sentence,
     )
@@ -3303,6 +3396,7 @@ def gendered_denom_analysis_de(
     lang,
     full_text,
     tokens,
+    offsets,
     words_data,
     false_positives,
 ):
@@ -3449,6 +3543,7 @@ def gendered_denom_analysis_de(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3467,6 +3562,7 @@ def style_word_analysis_de(
     lang,
     full_text,
     tokens,
+    offsets,
     df_sentences,
     words_data,
     sentences_data,
@@ -3518,6 +3614,7 @@ def style_word_analysis_de(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3531,6 +3628,7 @@ def style_word_analysis_de(
         lang,
         full_text,
         tokens,
+        offsets,
         sentences_data,
         df_sentences,
     )
@@ -3542,6 +3640,7 @@ def word_noun(
     lang,
     full_text,
     tokens,
+    offsets,
     words_data,
     matches_false=None,
 ):
@@ -3600,6 +3699,7 @@ def word_noun(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3681,6 +3781,7 @@ def rules_based_words_phrase_matcher(
     lang,
     full_text,
     tokens,
+    offsets,
     words_data,
     sentences_data=None,
     df_sentence=None,
@@ -3789,6 +3890,7 @@ def rules_based_words_phrase_matcher(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3809,6 +3911,7 @@ def rules_based_words_phrase_matcher(
         lang,
         full_text,
         tokens,
+        offsets,
         sentences_data,
         df_sentence,
         fallback_subcategory,
@@ -3822,6 +3925,7 @@ def homonyms_en(
     lang,
     full_text,
     tokens,
+    offsets,
     matches_false,
     words_data,
 ):
@@ -3851,6 +3955,7 @@ def homonyms_en(
                     lang,
                     text,
                     full_text,
+                    offsets,
                     subcategory,
                     start,
                     None,
@@ -3868,6 +3973,7 @@ def literal_match(
     lang,
     full_text,
     tokens,
+    offsets,
     df_sentence,
     term_list,
     lower_case=False,
@@ -3905,6 +4011,7 @@ def literal_match(
                     lang,
                     span.text,
                     full_text,
+                    offsets,
                     subcategory,
                     span.start_char,
                     span.end_char,
@@ -3920,6 +4027,7 @@ def detect_lower_cased_hashtags(
     config: Config,
     lang,
     full_text,
+    offsets,
 ):
     subcategory = "style"
 
@@ -3945,6 +4053,7 @@ def detect_lower_cased_hashtags(
                     lang,
                     "#" + text,
                     full_text,
+                    offsets,
                     subcategory,
                     span.start(),
                     span.end(),

--- a/app/models.py
+++ b/app/models.py
@@ -442,6 +442,7 @@ class ResultOut(BaseModel):
         lang: Language,
         text,
         full_text,
+        offsets,
         subcategory,
         start,
         end=None,
@@ -557,13 +558,20 @@ class ResultOut(BaseModel):
         else:
             gravity = map_gravity(subcategory)
 
+        if offsets and len(offsets["chars"]) > end:
+            utf16_start = offsets["chars"][start]
+            utf16_end = offsets["chars"][end]
+        else:
+            utf16_start = start
+            utf16_end = end
+
         return ResultOut(
             text=text,
             context=context,
             category=category,
             subcategory=subcategory,
-            start=start,
-            end=end,
+            start=utf16_start,
+            end=utf16_end,
             alternatives=alternatives,
             label=label,
             explanation=explanation,

--- a/tests/test_general_cases/test_api_multibyte/input.json
+++ b/tests/test_general_cases/test_api_multibyte/input.json
@@ -1,0 +1,3 @@
+{
+    "text": "😀 Power 𐐀 is our gooal my ninja"
+}

--- a/tests/test_general_cases/test_api_multibyte/output.json
+++ b/tests/test_general_cases/test_api_multibyte/output.json
@@ -1,0 +1,96 @@
+{
+    "language": "en",
+    "limit_reached": false,
+    "results": [
+        {
+            "alternatives": [
+                {
+                    "text": "goal"
+                },
+                {
+                    "text": "gooey"
+                },
+                {
+                    "text": "Gomal"
+                }
+            ],
+            "category": "orthography",
+            "context": "😀 Power 𐐀 is our gooal my ninja",
+            "end": 24,
+            "explanation": {
+                "icon": "❌",
+                "text": "Possible spelling mistake found."
+            },
+            "gravity": 1.0,
+            "label": "Spelling mistake",
+            "start": 19,
+            "subcategory": "typos",
+            "text": "gooal"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "skilled person"
+                },
+                {
+                    "text": "very proficient person"
+                },
+                {
+                    "text": "resourceful person"
+                },
+                {
+                    "text": "they"
+                },
+                {
+                    "text": "skilled people"
+                }
+            ],
+            "category": "social-motive",
+            "context": "😀 Power 𐐀 is our gooal my ninja",
+            "end": 33,
+            "explanation": {
+                "content": "advanced",
+                "icon": "😮‍💨",
+                "text": "Over-the-top statements make you sound less trustworthy",
+                "url": "https://www.witty.works/en/categories/social-motive/exaggeration?reducedView=true"
+            },
+            "gravity": 2.0,
+            "label": "Social Motive: Exaggeration",
+            "proficiency_level": "unconscious_bias",
+            "start": 28,
+            "subcategory": "exaggerating",
+            "text": "ninja"
+        },
+        {
+            "alternatives": [
+                {
+                    "text": "capacity"
+                },
+                {
+                    "text": "energy"
+                },
+                {
+                    "text": "aptitude"
+                },
+                {
+                    "text": "capacities"
+                }
+            ],
+            "category": "social-motive",
+            "context": "😀 Power 𐐀 is our gooal my ninja",
+            "end": 8,
+            "explanation": {
+                "content": "video",
+                "icon": "😒",
+                "text": "Doesn’t resonate with team-minded people",
+                "url": "https://www.witty.works/en/categories/social-motive/agentic-language?reducedView=true"
+            },
+            "gravity": 2.0,
+            "label": "Social Motive: Agentic language",
+            "proficiency_level": "unconscious_bias",
+            "start": 3,
+            "subcategory": "agentic",
+            "text": "Power"
+        }
+    ]
+}


### PR DESCRIPTION
Java and Javascript use UTF-16, where Python uses 1 char per unicode character

* https://betterprogramming.pub/slicing-strings-containing-emoji-differences-between-python-and-javascript-4716c419718f
* https://stackoverflow.com/questions/65971218/python3-counting-utf-16-code-points-in-a-string

fixes https://github.com/witty-works/nlp_api/issues/803