### PR TITLE
convert 's' (ie. substantive) to 'n' (ie. noun) for better clarity

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -121,7 +121,7 @@ for spacy_model in settings.models:
 rules = fetch_rules(model)
 
 # https://www.notion.so/witty-works/Rule-Guidelines-432792da944141b1b4d0a01de290aa43#aac0d966bfeb4e33a5a346bba45d5ea8
-supported_word_types = {"s", "a", "adv", "v", "conj"}
+supported_word_types = {"n", "a", "adv", "v", "conj"}
 
 if settings.fasttext:
     pretrained_lang_model = os.getcwd() + "/training_data/lid.176.bin"
@@ -648,7 +648,7 @@ async def post_debug_rule(
             rule_data.lang,
             rule_data.lemma,
             tokenize(rule_data.lemma, rule_data.lang),
-            tuple(rule_data.word_types.split("|")),
+            rule_data.word_types,
             subcategory,
         )
 
@@ -2903,7 +2903,7 @@ def fetch_word_type(lang, token, word_type=None, single_word=None):
         return "v"
 
     if token.pos_ == "NOUN" or token.pos_ == "PRON":
-        return "s"
+        return "n"
 
     adj_tags = {
         "AFX",
@@ -2926,7 +2926,7 @@ def fetch_word_type(lang, token, word_type=None, single_word=None):
         return "a"
 
     if token.tag_ == "NN":
-        return "s"
+        return "n"
 
     if token.pos_ == "PROPN" and single_word is not None and len(word_type):
         return word_type[0:1]
@@ -3393,7 +3393,7 @@ def alternative_declension(lang, text, token, word_type, prepend_word, alternati
                         alternative_text = align_verb_form(
                             lang, text, token, alternative_token
                         )
-                    elif "s" == word_type and "s" == alternative_word_type:
+                    elif "n" == word_type and "n" == alternative_word_type:
                         if is_token_plural(lang, alternative_token):
                             is_plural_alternative = True
 

--- a/app/rules.py
+++ b/app/rules.py
@@ -44,10 +44,14 @@ class Rule:
         self.lang = lang
         self.lemma = lemma
         self.words = words
+        if isinstance(word_types, str):
+            # BC code s -> n
+            word_types = tuple(word_types.replace("s", "n").split("|"))
         self.word_types = word_types
-        self.subcategory = self.parse_subcategory(subcategory)
 
+        self.subcategory = self.parse_subcategory(subcategory)
         self.alternatives = self.filter_alternatives(alternatives)
+
         self.plural_alternatives = None
         self.secondary_subcategory = None
         self.false_positives = None
@@ -62,7 +66,7 @@ class Rule:
         if is_base_category(subcategory):
             subcategory = remove_base(subcategory)
             if get_proficiency_level(subcategory) == "openly_discriminating":
-                if len(self.word_types) > 0 and "s" in self.word_types[0]:
+                if len(self.word_types) > 0 and "n" in self.word_types[0]:
                     self.type = RuleType.SUBSTRING
             else:
                 self.type = RuleType.SUFFIX
@@ -112,7 +116,7 @@ def build_rules(
             lang,
             lemma,
             tuple([i.text for i in model.tokenizer(lemma)]),
-            tuple(df["Word_Type"][i].split("|")),
+            df["Word_Type"][i],
         )
 
         key = rule.words[0].lower()

--- a/bin/analyze_rules.py
+++ b/bin/analyze_rules.py
@@ -198,7 +198,7 @@ def get_data_from_files(model, locale, details):
                                                 % (alternative)
                                             )
 
-                                if "s" == word_type:
+                                if "n" == word_type:
                                     if (
                                         category != "openly_discriminating"
                                         and len(nouns[word]) == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -383,19 +383,19 @@ def test_parse_word_types():
         response = client.get(url)
         assert response.status_code == 422
 
-        response = client.get(url + "word_types=s")
+        response = client.get(url + "word_types=n")
         assert response.status_code == 422
 
-        response = client.get(url + "word_types=s|~v|s|c")
+        response = client.get(url + "word_types=n|~v|n|c")
         assert response.status_code == 422
 
-        response = client.get(url + "word_types=s|~v|s|=conj")
+        response = client.get(url + "word_types=n|~v|n|=conj")
         result = response.json()
 
         assert result == [
-            {"word_type": "s", "lower_case": True, "lemmatize": True},
+            {"word_type": "n", "lower_case": True, "lemmatize": True},
             {"word_type": "v", "lower_case": True, "lemmatize": False},
-            {"word_type": "s", "lower_case": True, "lemmatize": True},
+            {"word_type": "n", "lower_case": True, "lemmatize": True},
             {"word_type": "conj", "lower_case": False, "lemmatize": False},
         ]
 
@@ -1314,7 +1314,7 @@ def test_spacy():
         response_content = json.loads(response.content)
 
         expected = [
-            {"word_type": "emoji|~s|~|a|a|s||||emoji"},
+            {"word_type": "emoji|~n|~|a|a|n||||emoji"},
             {
                 "text": "👩🏻‍🚒",
                 "lemma": "👩🏻‍🚒",
@@ -1338,7 +1338,7 @@ def test_spacy():
                 "tag": "PDS",
                 "pos": "PRON",
                 "dep": "sb",
-                "word_type": "s",
+                "word_type": "n",
                 "morph": {
                     "Case": "Nom",
                     "Gender": "Neut",
@@ -1409,7 +1409,7 @@ def test_spacy():
                 "tag": "NN",
                 "pos": "NOUN",
                 "dep": "pd",
-                "word_type": "s",
+                "word_type": "n",
                 "morph": {"Case": "Nom", "Gender": "Masc", "Number": "Sing"},
                 "is_emoji": False,
                 "is_singular": True,


### PR DESCRIPTION
tracey requested this renaming since `s` / `substantive` is inconsistent with our other english based naming. ie. it should be `n` / `noun`

once merged we need to update https://www.notion.so/witty-works/Rule-Guidelines-432792da944141b1b4d0a01de290aa43#aac0d966bfeb4e33a5a346bba45d5ea8