### PR TITLE
improved false positive detection in german substring checks by removing standard prefixes/suffixes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3990,6 +3990,8 @@ def is_false_positive(full_text, token, rule):
         if partial_text.startswith(false_positive):
             return True
 
+    return False
+
 
 def rule_check(
     version: float,
@@ -4041,17 +4043,74 @@ def rule_check(
         if rule.type == RuleType.SUBSTRING:
             text = token.text
             token_lower = text.lower()
-            count = token_lower.count(rule.lemma.lower())
+            rule_lemma_lower = rule.lemma.lower()
+            count = token_lower.count(rule_lemma_lower)
             if count == 0:
                 continue
 
+            standard_words = [
+                "zusammen",
+                "schaft",
+                "nieder",
+                "hinter",
+                "wider",
+                "unter",
+                "reich",
+                "ismus",
+                "über",
+                "voll",
+                "nach",
+                "miss",
+                "ling",
+                "lich",
+                "lein",
+                "leer",
+                "keit",
+                "heit",
+                "haft",
+                "chen",
+                "zer",
+                "weg",
+                "vor",
+                "ver",
+                "ver",
+                "ung",
+                "tum",
+                "nis",
+                "mit",
+                "los",
+                "hin",
+                "her",
+                "ent",
+                "emp",
+                "ein",
+                "ein",
+                "dar",
+                "bei",
+                "aus",
+                "auf",
+                "arm",
+                "zu",
+                "un",
+                "um",
+                "ob",
+                "le",
+                "in",
+                "ge",
+                "er",
+                "be",
+                "an",
+                "ab",
+            ]
             if rule.false_positives is not None:
-                for false_positive in rule.false_positives:
-                    count -= token_lower.count(false_positive.lower())
-                    if count <= 0:
-                        break
+                standard_words = rule.false_positives + standard_words
 
-            if count <= 0:
+            for standard_word in standard_words:
+                if standard_word.lower() not in rule_lemma_lower:
+                    token_lower = token_lower.replace(standard_word.lower(), "")
+
+            count = token_lower.count(rule_lemma_lower)
+            if count == 0:
                 continue
 
             skip_token = i + 1

--- a/tests/test_general_cases/test_german_titles_postfix/input.json
+++ b/tests/test_general_cases/test_german_titles_postfix/input.json
@@ -1,6 +1,8 @@
 {
-  "text": "Unser Facharzt weiß alles. Fachärzte liefern wissen. Hier sind viele Juden. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht.",
+  "text": "Unser Facharzt weiß alles. Fachärzte liefern wissen. Hier sind viele Juden. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht. Das du das mitunterzeichnet?",
   "config": {
-    "disabled_categories": ["orthography"]
+    "disabled_categories": [
+      "orthography"
+    ]
   }
 }

--- a/tests/test_general_cases/test_german_titles_postfix/output.json
+++ b/tests/test_general_cases/test_german_titles_postfix/output.json
@@ -180,7 +180,7 @@
                 }
             ],
             "category": "gender-orientation",
-            "context": "achärzte liefern wissen. Hier sind viele Juden. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht.",
+            "context": "achärzte liefern wissen. Hier sind viele Juden. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht. Das",
             "end": 138,
             "explanation": {
                 "icon": "🚫",
@@ -201,7 +201,7 @@
                 }
             ],
             "category": "gender-orientation",
-            "context": "Hier sind viele Juden. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht.",
+            "context": "Hier sind viele Juden. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht. Das du das mitunterzeichnet?",
             "end": 171,
             "explanation": {
                 "icon": "🚫",
@@ -228,7 +228,7 @@
                 }
             ],
             "category": "gender-orientation",
-            "context": "n. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht.",
+            "context": "n. Er hat ein Judenei. Hure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht. Das du das mitunterzeichnet?",
             "end": 186,
             "explanation": {
                 "content": "advanced",
@@ -256,7 +256,7 @@
                 }
             ],
             "category": "gender-orientation",
-            "context": "ure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht.",
+            "context": "ure. Hurehund. Katzenhurehund. Katzenhure. Mandschure. Mandschurehuremhure. Ein Ingenieur kann das. Ein Elektroingenieur kann das nicht. Das du das mitunterzeichnet?",
             "end": 217,
             "explanation": {
                 "content": "advanced",


### PR DESCRIPTION
Idea is to remove common german prefix/suffix to reduce risk of false postives for substring matching (ie. `tunte` being found inside `mitunterzeichnet`).