### PR TITLE
fetch and cache the RSA key instead of configuring via env vars

### DIFF
--- a/app/auth_service.py
+++ b/app/auth_service.py
@@ -24,6 +24,7 @@ SOFTWARE.
 
 from fastapi import Request
 from jose import jwt
+from async_lru import alru_cache
 
 
 class AuthError(Exception):
@@ -44,34 +45,46 @@ def get_unverified_token_claims(request: Request):
     return get_unverified_token_claims_(token)
 
 
-def decode_b2c_jwt(
+async def get_rsa_key(session, token, url):
+    unverified_header = jwt.get_unverified_header(token)
+    return await get_rsa_key_(session, unverified_header["kid"], url)
+
+
+async def decode_b2c_jwt(
+    session,
     request: Request,
-    rsa_key: dict,
-    tenant_id_: str,
-    client_id_: str,
-    b2c_domain_name_: str,
+    tenant_id: str,
+    client_id: str,
+    b2c_domain_name: str,
+    b2c_policy_name: str,
     scope: str,
 ):
     token = get_token_auth_header(request)
-    issuer = f"https://{b2c_domain_name_}.b2clogin.com/{tenant_id_}/v2.0/".lower()
-    audience = client_id_
+    issuer = f"https://{b2c_domain_name}.b2clogin.com/{tenant_id}/v2.0/".lower()
+    audience = client_id
+
+    key_url = f"https://{b2c_domain_name}.b2clogin.com/{b2c_domain_name}.onmicrosoft.com/{b2c_policy_name}/discovery/v2.0/keys"
+    rsa_key = await get_rsa_key(session, token, key_url)
 
     return decode_jwt_(token, rsa_key, issuer, audience, scope)
 
 
-def decode_jwt(
-    request: Request, rsa_key: dict, tenant_id_: str, client_id_: str, scope: str
+async def decode_jwt(
+    session, request: Request, tenant_id: str, client_id: str, scope: str
 ):
     token = get_token_auth_header(request)
-    issuer = f"https://login.microsoftonline.com/{tenant_id_}/v2.0"
-    audience = f"{client_id_}"
+    issuer = f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+    audience = f"{client_id}"
+
+    key_url = f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
+    rsa_key = await get_rsa_key(session, token, key_url)
 
     return decode_jwt_(token, rsa_key, issuer, audience, scope)
 
 
 def decode_jwt_(
     token: str,
-    rsa_key: str,
+    rsa_key: dict,
     issuer: str,
     audience: str,
     scope: str,
@@ -141,3 +154,24 @@ def get_token_(auth: str):
 def get_unverified_token_claims_(token: str):
     unverified_claims = jwt.get_unverified_claims(token)
     return unverified_claims
+
+
+@alru_cache(maxsize=8)
+async def get_rsa_key_(session, kid, url):
+    async with session.get(url) as r:
+        if r.status != 200:  # pragma: no cover
+            error = await r.text()
+            raise AuthError("Fetching RSA key resulted: " + error)
+
+        jwks = await r.json()
+        for key in jwks["keys"]:
+            if key["kid"] == kid:
+                return {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key["use"],
+                    "n": key["n"],
+                    "e": key["e"],
+                }
+
+    raise AuthError("Unable to fetch RSA key")

--- a/app/main.py
+++ b/app/main.py
@@ -534,7 +534,7 @@ async def get_config_debug(
 async def post_auth_debug(
     request: Request, user_request_in: RequestIn
 ):  # pragma: no cover
-    user_email = fetch_user(request)
+    user_email = await fetch_user(request)
     if not user_email:
         return user_email
 
@@ -567,7 +567,7 @@ async def post_auth_2_0(request: Request, user_request_in: BaseRequestIn = None)
     )
     check_client_version(client)
 
-    user_email = fetch_user(request)
+    user_email = await fetch_user(request)
     if not user_email:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -1152,7 +1152,7 @@ def fetch_email_from_claims(claims):
     )
 
 
-def fetch_user(request: Request):
+async def fetch_user(request: Request):
     if "authorization" in request.headers and request.headers[
         "authorization"
     ].lower().startswith("bearer"):
@@ -1167,21 +1167,22 @@ def fetch_user(request: Request):
                     continue
 
                 if "domain" in config:
-                    claims = decode_b2c_jwt(
+                    claims = await decode_b2c_jwt(
+                        ssl_session,
                         request,
-                        config["rsa_key"],
                         config["tenant_id"],
                         config["client_id"],
                         config["domain"],
-                        settings.aadb2c_expected_scope,
+                        config["policy"],
+                        config["expected_scope"],
                     )
                 else:
-                    claims = decode_jwt(
+                    claims = await decode_jwt(
+                        ssl_session,
                         request,
-                        config["rsa_key"],
                         config["tenant_id"],
                         config["client_id"],
-                        settings.aadb2c_expected_scope,
+                        config["expected_scope"],
                     )
 
                 return fetch_email_from_claims(claims)
@@ -1254,7 +1255,7 @@ async def check(
     if version is not None:
         check_api_version(version)
 
-        user_email = fetch_user(request)
+        user_email = await fetch_user(request)
         configs = await fetch_configs_for_request(version, user_request_in, user_email)
     else:
         # debug

--- a/app/settings.py
+++ b/app/settings.py
@@ -35,18 +35,11 @@ class Settings(BaseSettings):
     aadb2c_policy: Optional[str] = ""
     aadb2c_domain: Optional[str] = ""
     aadb2c_expected_scope: Optional[str] = ""
-    aadb2c_rsa_kid: Optional[str] = ""
-    aadb2c_rsa_kty: str = "RSA"
-    aadb2c_rsa_n: Optional[str] = ""
-    aadb2c_rsa_e: str = "AQAB"
 
     office_sso_tenant_id: Optional[str] = ""
     office_sso_client_id: Optional[str] = ""
     office_sso_expected_scope: Optional[str] = ""
-    office_sso_rsa_kid: Optional[str] = ""
-    office_sso_rsa_kty: str = "RSA"
-    office_sso_rsa_n: Optional[str] = ""
-    office_sso_rsa_e: str = "AQAB"
+
 
     sso_configs: dict = {}
 
@@ -87,23 +80,11 @@ def get_settings():
             "policy": settings.aadb2c_policy,
             "domain": settings.aadb2c_domain,
             "expected_scope": settings.aadb2c_expected_scope,
-            "rsa_key": {
-                "kid": settings.aadb2c_rsa_kid,
-                "kty": settings.aadb2c_rsa_kty,
-                "e": settings.aadb2c_rsa_e,
-                "n": settings.aadb2c_rsa_n,
-            },
         },
         "office_sso": {
             "tenant_id": settings.office_sso_tenant_id,
             "client_id": settings.office_sso_client_id,
             "expected_scope": settings.office_sso_expected_scope,
-            "rsa_key": {
-                "kid": settings.office_sso_rsa_kid,
-                "kty": settings.office_sso_rsa_kty,
-                "e": settings.office_sso_rsa_e,
-                "n": settings.office_sso_rsa_n,
-            },
         },
     }
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "dev"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:8026e24e9c1f366aa967da94bfb74e0bbbd647428100efab4f1860bbd74ecde6"
+content_hash = "sha256:81ac752886e8296c107ec9752c306b1cc028c0f729682303aeae903b93ea1754"
 
 [[package]]
 name = "aiofiles"
@@ -86,6 +86,16 @@ dependencies = [
 files = [
     {file = "anyio-3.7.1-py3-none-any.whl", hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5"},
     {file = "anyio-3.7.1.tar.gz", hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780"},
+]
+
+[[package]]
+name = "async-lru"
+version = "2.0.4"
+requires_python = ">=3.8"
+summary = "Simple LRU cache for asyncio"
+files = [
+    {file = "async-lru-2.0.4.tar.gz", hash = "sha256:b8a59a5df60805ff63220b2a0c5b5393da5521b113cd5465a44eb037d81a5627"},
+    {file = "async_lru-2.0.4-py3-none-any.whl", hash = "sha256:ff02944ce3c288c5be660c42dbcca0742b32c3b279d6dceda655190240b99224"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "emoji>=0.6.0",
     "cmp-version>=3.0.0",
     "python-jose>=3.3.0",
+    "async-lru>=2.0.4",
 ]
 requires-python = ">=3.11"
 license = "Proprietary"


### PR DESCRIPTION
it seems like the `kid` in the tokens (specifically for MS Office SSO) get updated which in turn leads to a new RSA key being needed to verify the signature.

example `kid` contained within a JWT token header
```
{
  "typ": "JWT",
  "alg": "RS256",
  "kid": "T1St-dLTvyWRgxB_676u8krXS-I"
}
```

these changes mean that we no longer configure this but instead fetch and construct the RSA key dynamically based on the `kid` value in the JWT token.

additionally we cache the RSA key so that we do not need to constantly fetch this information. maxsize is `8` which should means that as long as the different `kid` values currently floating aroung isn't more than that, it should be fine.

since the MS Office SSO tokens are short lived, we should not have more than 2 `kid` values from them at any point in time.

the `kid` value for Azure AD B2C we control, so as long as we don't change it too often over the course of a year (so far we have never), it should not be a problem. also in that case all that will happen is the user will get a 403, which will result in getting a new token which should have the updated `kid`.